### PR TITLE
Coerce requests from string or buffer.

### DIFF
--- a/samples/detect.js
+++ b/samples/detect.js
@@ -29,7 +29,7 @@ function detectFaces(fileName) {
   // const fileName = 'Local image file, e.g. /path/to/image.png';
 
   client
-    .faceDetection({image: {source: {filename: fileName}}})
+    .faceDetection(fileName)
     .then(results => {
       const faces = results[0].faceAnnotations;
 
@@ -62,17 +62,9 @@ function detectFacesGCS(bucketName, fileName) {
   // const bucketName = 'Bucket where the file resides, e.g. my-bucket';
   // const fileName = 'Path to file within bucket, e.g. path/to/image.png';
 
-  const request = {
-    image: {
-      source: {
-        imageUri: `gs://${bucketName}/${fileName}`,
-      },
-    },
-  };
-
   // Performs face detection on the gcs file
   client
-    .faceDetection(request)
+    .faceDetection(`gs://${bucketName}/${fileName}`)
     .then(results => {
       const faces = results[0].faceAnnotations;
 
@@ -106,7 +98,7 @@ function detectLabels(fileName) {
 
   // Performs label detection on the local file
   client
-    .labelDetection({image: {source: {filename: fileName}}})
+    .labelDetection(fileName)
     .then(results => {
       const labels = results[0].labelAnnotations;
       console.log('Labels:');
@@ -132,17 +124,9 @@ function detectLabelsGCS(bucketName, fileName) {
   // const bucketName = 'Bucket where the file resides, e.g. my-bucket';
   // const fileName = 'Path to file within bucket, e.g. path/to/image.png';
 
-  const request = {
-    image: {
-      source: {
-        imageUri: `gs://${bucketName}/${fileName}`,
-      },
-    },
-  };
-
   // Performs label detection on the gcs file
   client
-    .labelDetection(request)
+    .labelDetection(`gs://${bucketName}/${fileName}`)
     .then(results => {
       const labels = results[0].labelAnnotations;
       console.log('Labels:');
@@ -168,7 +152,7 @@ function detectLandmarks(fileName) {
 
   // Performs landmark detection on the local file
   client
-    .landmarkDetection({image: {source: {filename: fileName}}})
+    .landmarkDetection(fileName)
     .then(results => {
       const landmarks = results[0].landmarkAnnotations;
       console.log('Landmarks:');
@@ -194,17 +178,9 @@ function detectLandmarksGCS(bucketName, fileName) {
   // const bucketName = 'Bucket where the file resides, e.g. my-bucket';
   // const fileName = 'Path to file within bucket, e.g. path/to/image.png';
 
-  const request = {
-    image: {
-      source: {
-        imageUri: `gs://${bucketName}/${fileName}`,
-      },
-    },
-  };
-
   // Performs landmark detection on the gcs file
   client
-    .landmarkDetection(request)
+    .landmarkDetection(`gs://${bucketName}/${fileName}`)
     .then(results => {
       const landmarks = results[0].landmarkAnnotations;
       console.log('Landmarks:');
@@ -230,7 +206,7 @@ function detectText(fileName) {
 
   // Performs text detection on the local file
   client
-    .textDetection({image: {source: {filename: fileName}}})
+    .textDetection(fileName)
     .then(results => {
       const detections = results[0].textAnnotations;
       console.log('Text:');
@@ -256,17 +232,9 @@ function detectTextGCS(bucketName, fileName) {
   // const bucketName = 'Bucket where the file resides, e.g. my-bucket';
   // const fileName = 'Path to file within bucket, e.g. path/to/image.png';
 
-  const request = {
-    image: {
-      source: {
-        imageUri: `gs://${bucketName}/${fileName}`,
-      },
-    },
-  };
-
   // Performs text detection on the gcs file
   client
-    .textDetection(request)
+    .textDetection(`gs://${bucketName}/${fileName}`)
     .then(results => {
       const detections = results[0].textAnnotations;
       console.log('Text:');
@@ -292,7 +260,7 @@ function detectLogos(fileName) {
 
   // Performs logo detection on the local file
   client
-    .logoDetection({image: {source: {filename: fileName}}})
+    .logoDetection(fileName)
     .then(results => {
       const logos = results[0].logoAnnotations;
       console.log('Logos:');
@@ -318,17 +286,9 @@ function detectLogosGCS(bucketName, fileName) {
   // const bucketName = 'Bucket where the file resides, e.g. my-bucket';
   // const fileName = 'Path to file within bucket, e.g. path/to/image.png';
 
-  const request = {
-    image: {
-      source: {
-        imageUri: `gs://${bucketName}/${fileName}`,
-      },
-    },
-  };
-
   // Performs logo detection on the gcs file
   client
-    .logoDetection(request)
+    .logoDetection(`gs://${bucketName}/${fileName}`)
     .then(results => {
       const logos = results[0].logoAnnotations;
       console.log('Logos:');
@@ -354,7 +314,7 @@ function detectProperties(fileName) {
 
   // Performs property detection on the local file
   client
-    .imageProperties({image: {source: {filename: fileName}}})
+    .imageProperties(fileName)
     .then(results => {
       const properties = results[0].imagePropertiesAnnotation;
       const colors = properties.dominantColors.colors;
@@ -380,17 +340,9 @@ function detectPropertiesGCS(bucketName, fileName) {
   // const bucketName = 'Bucket where the file resides, e.g. my-bucket';
   // const fileName = 'Path to file within bucket, e.g. path/to/image.png';
 
-  const request = {
-    image: {
-      source: {
-        imageUri: `gs://${bucketName}/${fileName}`,
-      },
-    },
-  };
-
   // Performs property detection on the gcs file
   client
-    .imageProperties(request)
+    .imageProperties(`gs://${bucketName}/${fileName}`)
     .then(results => {
       const properties = results[0].imagePropertiesAnnotation;
       const colors = properties.dominantColors.colors;
@@ -416,7 +368,7 @@ function detectSafeSearch(fileName) {
 
   // Performs safe search detection on the local file
   client
-    .safeSearchDetection({image: {source: {filename: fileName}}})
+    .safeSearchDetection(fileName)
     .then(results => {
       const detections = results[0].safeSearchAnnotation;
 
@@ -445,17 +397,9 @@ function detectSafeSearchGCS(bucketName, fileName) {
   // const bucketName = 'Bucket where the file resides, e.g. my-bucket';
   // const fileName = 'Path to file within bucket, e.g. path/to/image.png';
 
-  const request = {
-    image: {
-      source: {
-        imageUri: `gs://${bucketName}/${fileName}`,
-      },
-    },
-  };
-
   // Performs safe search property detection on the remote file
   client
-    .safeSearchDetection(request)
+    .safeSearchDetection(`gs://${bucketName}/${fileName}`)
     .then(results => {
       const detections = results[0].safeSearchAnnotation;
 
@@ -486,7 +430,7 @@ function detectCropHints(fileName) {
 
   // Find crop hints for the local file
   client
-    .cropHints({image: {source: {filename: fileName}}})
+    .cropHints(fileName)
     .then(results => {
       const cropHints = results[0].cropHintsAnnotation;
 
@@ -518,17 +462,9 @@ function detectCropHintsGCS(bucketName, fileName) {
   // const bucketName = 'Bucket where the file resides, e.g. my-bucket';
   // const fileName = 'Path to file within bucket, e.g. path/to/image.png';
 
-  const request = {
-    image: {
-      source: {
-        imageUri: `gs://${bucketName}/${fileName}`,
-      },
-    },
-  };
-
   // Find crop hints for the remote file
   client
-    .cropHints(request)
+    .cropHints(`gs://${bucketName}/${fileName}`)
     .then(results => {
       const cropHints = results[0].cropHintsAnnotation;
 
@@ -561,7 +497,7 @@ function detectWeb(fileName) {
 
   // Detect similar images on the web to a local file
   client
-    .webDetection({image: {source: {filename: fileName}}})
+    .webDetection(fileName)
     .then(results => {
       const webDetection = results[0].webDetection;
 
@@ -614,17 +550,9 @@ function detectWebGCS(bucketName, fileName) {
   // const bucketName = 'Bucket where the file resides, e.g. my-bucket';
   // const fileName = 'Path to file within bucket, e.g. path/to/image.png';
 
-  const request = {
-    image: {
-      source: {
-        imageUri: `gs://${bucketName}/${fileName}`,
-      },
-    },
-  };
-
   // Detect similar images on the web to a remote file
   client
-    .webDetection(request)
+    .webDetection(`gs://${bucketName}/${fileName}`)
     .then(results => {
       const webDetection = results[0].webDetection;
 
@@ -678,7 +606,7 @@ function detectFulltext(fileName) {
 
   // Read a local image as a text document
   client
-    .documentTextDetection({image: {source: {filename: fileName}}})
+    .documentTextDetection(fileName)
     .then(results => {
       const fullTextAnnotation = results[0].fullTextAnnotation;
       console.log(fullTextAnnotation.text);
@@ -704,17 +632,9 @@ function detectFulltextGCS(bucketName, fileName) {
   // const bucketName = 'Bucket where the file resides, e.g. my-bucket';
   // const fileName = 'Path to file within bucket, e.g. path/to/image.png';
 
-  const request = {
-    image: {
-      source: {
-        imageUri: `gs://${bucketName}/${fileName}`,
-      },
-    },
-  };
-
   // Read a remote image as a text document
   client
-    .documentTextDetection(request)
+    .documentTextDetection(`gs://${bucketName}/${fileName}`)
     .then(results => {
       const fullTextAnnotation = results[0].fullTextAnnotation;
       console.log(fullTextAnnotation.text);

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -22,21 +22,9 @@ const vision = require('@google-cloud/vision');
 // Creates a client
 const client = new vision.ImageAnnotatorClient();
 
-// The name of the image file to annotate
-const fileName = './resources/wakeupcat.jpg';
-
-// Prepare the request object
-const request = {
-  image: {
-    source: {
-      filename: fileName,
-    },
-  },
-};
-
 // Performs label detection on the image file
 client
-  .labelDetection(request)
+  .labelDetection('./resources/wakeupcat.jpg')
   .then(results => {
     const labels = results[0].labelAnnotations;
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -79,7 +79,7 @@ let _coerceRequest = (request, callback) => {
   if (request.image.source && request.image.source.filename) {
     fs.readFile(
       request.image.source.filename,
-      {encoding: 'base64'},
+      {encoding: null},
       (err, blob) => {
         if (err) {
           callback(err);
@@ -87,13 +87,12 @@ let _coerceRequest = (request, callback) => {
         }
         request.image.content = blob.toString('base64');
         delete request.image.source;
+        return callback(null, request);
       }
     );
+  } else {
+    return callback(null, request);
   }
-
-  // Done; run the callback with the AnnotateImageRequest.
-  callback(null, request);
-  return;
 };
 
 /*!

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -33,7 +33,7 @@ const gax = require('google-gax');
  * @returns An object representing an AnnotateImageRequest.
  */
 let _requestToObject = request => {
-  if (is.string(request) === true) {
+  if (is.string(request)) {
     // Is this a URL or a local file?
     // Guess based on what the string looks like, and build the full
     // request object in the correct format.

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -77,19 +77,15 @@ let _coerceRequest = (request, callback) => {
   // If the file is specified as a filename and exists on disk, read it
   // and coerce it into the base64 content.
   if (request.image.source && request.image.source.filename) {
-    fs.readFile(
-      request.image.source.filename,
-      {encoding: null},
-      (err, blob) => {
-        if (err) {
-          callback(err);
-          return;
-        }
-        request.image.content = blob.toString('base64');
-        delete request.image.source;
-        return callback(null, request);
+    fs.readFile(request.image.source.filename, (err, blob) => {
+      if (err) {
+        callback(err);
+        return;
       }
-    );
+      request.image.content = blob.toString('base64');
+      delete request.image.source;
+      return callback(null, request);
+    });
   } else {
     return callback(null, request);
   }

--- a/system-test/vision.js
+++ b/system-test/vision.js
@@ -81,43 +81,25 @@ describe('Vision', function() {
 
   it('should detect from a URL', () => {
     var url = 'https://upload.wikimedia.org/wikipedia/commons/5/51/Google.png';
-    return client
-      .logoDetection({
-        image: {
-          source: {imageUri: url},
-        },
-      })
-      .then(responses => {
-        var response = responses[0];
-        assert.deepEqual(response.logoAnnotations[0].description, 'Google');
-      });
+    return client.logoDetection(url).then(responses => {
+      var response = responses[0];
+      assert.deepEqual(response.logoAnnotations[0].description, 'Google');
+    });
   });
 
   it('should detect from a filename', () => {
-    return client
-      .logoDetection({
-        image: {
-          source: {filename: IMAGES.logo},
-        },
-      })
-      .then(responses => {
-        var response = responses[0];
-        assert.deepEqual(response.logoAnnotations[0].description, 'Google');
-      });
+    return client.logoDetection(IMAGES.logo).then(responses => {
+      var response = responses[0];
+      assert.deepEqual(response.logoAnnotations[0].description, 'Google');
+    });
   });
 
   it('should detect from a Buffer', () => {
     var buffer = fs.readFileSync(IMAGES.logo);
-    return client
-      .logoDetection({
-        image: {
-          content: buffer,
-        },
-      })
-      .then(responses => {
-        var response = responses[0];
-        assert.deepEqual(response.logoAnnotations[0].description, 'Google');
-      });
+    return client.logoDetection(buffer).then(responses => {
+      var response = responses[0];
+      assert.deepEqual(response.logoAnnotations[0].description, 'Google');
+    });
   });
 
   describe('single image', () => {

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -69,7 +69,7 @@ describe('Vision helper methods', () => {
       });
     });
 
-    it('understands buffers', () => {
+    it('understands buffers in a request object', () => {
       let client = new vision.v1.ImageAnnotatorClient(CREDENTIALS);
 
       // Stub out the batch annotation method.
@@ -274,14 +274,13 @@ describe('Vision helper methods', () => {
         .annotateImage(request)
         .then(assert.fail)
         .catch(err => {
-          let expected = 'Attempted to call `annotateImage` with no image.';
-          assert(err.message === expected);
+          assert(err.message === 'No image present.');
         });
     });
   });
 
   describe('single-feature methods', () => {
-    it('calls annotateImage with the correct feature', () => {
+    it('call `annotateImage` with the correct feature', () => {
       let client = new vision.v1.ImageAnnotatorClient(CREDENTIALS);
       let annotate = sandbox.spy(client, 'annotateImage');
       let batchAnnotate = sandbox.stub(client, 'batchAnnotateImages');
@@ -322,7 +321,152 @@ describe('Vision helper methods', () => {
       });
     });
 
-    it('throws an exception if conflicting features are given', () => {
+    it('accept a URL as a string', () => {
+      let client = new vision.v1.ImageAnnotatorClient(CREDENTIALS);
+
+      // Stub out the batch annotation method.
+      let batchAnnotate = sandbox.stub(client, 'batchAnnotateImages');
+      batchAnnotate.callsArgWith(2, undefined, {
+        responses: [
+          {
+            logoAnnotations: [{description: 'Google'}],
+          },
+        ],
+      });
+
+      // Call a request to a single-feature method using a URL.
+      return client.logoDetection('https://goo.gl/logo.png').then(r => {
+        let response = r[0];
+
+        // Ensure we got the slice of the response that we expected.
+        assert.deepEqual(response, {
+          logoAnnotations: [{description: 'Google'}],
+        });
+
+        // Inspect the calls to batchAnnotateImages and ensure they matched
+        // the expected signature.
+        assert(batchAnnotate.callCount === 1);
+        assert(
+          batchAnnotate.calledWith({
+            requests: [
+              {
+                image: {source: {imageUri: 'https://goo.gl/logo.png'}},
+                features: [{type: 3}],
+              },
+            ],
+          })
+        );
+      });
+    });
+
+    it('accept a filename as a string', () => {
+      let client = new vision.v1.ImageAnnotatorClient(CREDENTIALS);
+
+      // Stub out the batch annotation method.
+      let annotate = sandbox.stub(client, 'annotateImage');
+      annotate.callsArgWith(2, undefined, {
+        logoAnnotations: [{description: 'Google'}],
+      });
+
+      // Call a request to a single-feature method using a URL.
+      return client.logoDetection('/path/to/logo.png').then(response => {
+        // Ensure we got the slice of the response that we expected.
+        assert.deepEqual(response, [
+          {
+            logoAnnotations: [{description: 'Google'}],
+          },
+        ]);
+
+        // Inspect the calls to annotateImages and ensure they matched
+        // the expected signature.
+        assert(annotate.callCount === 1);
+        assert(
+          annotate.calledWith({
+            image: {source: {filename: '/path/to/logo.png'}},
+            features: [{type: 3}],
+          })
+        );
+      });
+    });
+
+    it('understand a buffer sent directly', () => {
+      let client = new vision.v1.ImageAnnotatorClient(CREDENTIALS);
+
+      // Stub out the batch annotation method.
+      let batchAnnotate = sandbox.stub(client, 'batchAnnotateImages');
+      batchAnnotate.callsArgWith(2, undefined, {
+        responses: [
+          {
+            logoAnnotations: [{description: 'Google'}],
+          },
+        ],
+      });
+
+      // Ensure that the annotateImage method arrifies the request and
+      // passes it through to the batch annotation method.
+      return client.logoDetection(Buffer.from('fakeImage')).then(r => {
+        let response = r[0];
+
+        // Ensure that we got the slice of the response that we expected.
+        assert.deepEqual(response, {
+          logoAnnotations: [{description: 'Google'}],
+        });
+
+        // Inspect the calls to batchAnnotateImages and ensure they matched
+        // the expected signature.
+        assert(batchAnnotate.callCount === 1);
+        assert(
+          batchAnnotate.calledWith({
+            requests: [
+              {
+                image: {content: 'ZmFrZUltYWdl'},
+                features: [{type: 3}],
+              },
+            ],
+          })
+        );
+      });
+    });
+
+    it('handle being sent call options', () => {
+      let client = new vision.v1.ImageAnnotatorClient(CREDENTIALS);
+      let opts = {foo: 'bar'};
+
+      // Stub out the batchAnnotateImages method as usual.
+      let batchAnnotate = sandbox.stub(client, 'batchAnnotateImages');
+      batchAnnotate.callsArgWith(2, undefined, {
+        responses: [
+          {
+            logoAnnotations: [{description: 'Google'}],
+          },
+        ],
+      });
+
+      // Perform the request. Send `opts` as an explicit second argument
+      // to ensure that sending call options works appropriately.
+      return client.logoDetection(Buffer.from('fakeImage'), opts).then(r => {
+        let response = r[0];
+        assert.deepEqual(response, {
+          logoAnnotations: [{description: 'Google'}],
+        });
+
+        // Inspect the calls to batchAnnotateImages and ensure they matched
+        // the expected signature.
+        assert(batchAnnotate.callCount === 1);
+        assert(
+          batchAnnotate.calledWith({
+            requests: [
+              {
+                image: {content: 'ZmFrZUltYWdl'},
+                features: [{type: 3}],
+              },
+            ],
+          })
+        );
+      });
+    });
+
+    it('throw an exception if conflicting features are given', () => {
       let client = new vision.v1.ImageAnnotatorClient(CREDENTIALS);
       let imageRequest = {
         image: {content: Buffer.from('bogus==')},

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -115,7 +115,7 @@ describe('Vision helper methods', () => {
       let readFile = sandbox.stub(fs, 'readFile');
       readFile
         .withArgs('image.jpg')
-        .callsArgWith(2, null, Buffer.from('fakeImage'));
+        .callsArgWith(1, null, Buffer.from('fakeImage'));
       readFile.callThrough();
 
       // Stub out the batch annotation method as before.
@@ -164,7 +164,7 @@ describe('Vision helper methods', () => {
       // Stub out `fs.readFile` and return a bogus image object.
       // This allows us to test filename detection.
       let readFile = sandbox.stub(fs, 'readFile');
-      readFile.withArgs('image.jpg').callsArgWith(2, {error: 404});
+      readFile.withArgs('image.jpg').callsArgWith(1, {error: 404});
       readFile.callThrough();
 
       // Ensure that the annotateImage method arrifies the request and


### PR DESCRIPTION
Hey @jgeewax, @stephenplusplus, @jmdobry, (cc: @remi)
Background: JJ pinged me a couple weeks ago asking about the breaking changes between Vision 0.11.6 and 0.12.0. Essentially, we went from "we accept a string with the URL" to "send a big object". In the change moving to 0.12.0, our single-feature methods take the image object, but as part of [GCN #2553](https://github.com/GoogleCloudPlatform/google-cloud-node/issues/2553) and [GCN #2555](https://github.com/GoogleCloudPlatform/google-cloud-node/pull/2555), we actually are moving it to having to send the entire request structure:

```es6
client.faceDetection({image: {source: {imageUri: 'gs://...'}}}).then(response => {
  ...
});
```

The reason why we were doing this was to alter the request structure as little as possible to ensure forward compatibility. JJ asked, essentially, "For the simplest of cases...you only want to specify an image, why can you not detect non-objects and convert appropriately?" For example:

```es6
client.faceDetection('gs://...').then(response => { ... });
```

I responded, honestly, "Because I did not think of that at the time." I was focused on modifying the request as little as possible and *only* stripping out the feature flag and moving it over to the method, but the proposal has a lot of value. It does still mean that if you want to specify _anything_ else at all (e.g. the `imageContext` case), you have to send the full `AnnotateImageRequest` structure, but that is where we are landing anyway.

We merged the (breaking) fix from [GCN #2555](https://github.com/GoogleCloudPlatform/google-cloud-node/pull/2555) but never actually launched it, so when we launch this repo-migration, there will be a breaking change involved. JJ's proposed fix here is additive, but it would be nice if we could reduce randomization on users as much as possible. I need to put a bow on this release soon to accommodate the v1p1beta1 release.

I have whipped up what the code (and docs) would essentially need to be if we did this. Is this something everyone would be happy with? If so, I will get the appropriate tests and such in place.

Fixes #2.