### PR TITLE
Remove unused "imports" region tag from v1p1beta1 sample

### DIFF
--- a/samples/detect.v1p1beta1.js
+++ b/samples/detect.v1p1beta1.js
@@ -17,10 +17,8 @@
 
 function detectFulltext(fileName) {
   // [START vision_detect_document]
-  // [START imports]
   // Imports the Google Cloud client libraries
   const vision = require('@google-cloud/vision').v1p1beta1;
-  // [END imports]
 
   // Creates a client
   const client = new vision.ImageAnnotatorClient();


### PR DESCRIPTION
*TEXT-ONLY CHANGE*

We decided this region tag is not necessary (we are in-lining this 1 LOC in the docs)

/cc @dizcology @nnegrey for Python/Java
