### PR TITLE
releasing v0.15.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/vision",
   "description": "Google Cloud Vision API client for Node.js",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "license": "Apache-2.0",
   "author": "Google Inc",
   "engines": {

--- a/samples/package.json
+++ b/samples/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@google-cloud/storage": "1.4.0",
-    "@google-cloud/vision": "0.15.0",
+    "@google-cloud/vision": "0.15.1",
     "async": "2.5.0",
     "natural": "0.5.4",
     "redis": "2.8.0",


### PR DESCRIPTION
Need to release a new version to npm to upgrade dependencies on @google-cloud/common. The currently released version requires 0.15.x which is older than we need.