### PR TITLE
regenerate GAPIC v1p2beta1 code

### DIFF
--- a/protos/google/cloud/vision/v1p2beta1/image_annotator.proto
+++ b/protos/google/cloud/vision/v1p2beta1/image_annotator.proto
@@ -599,6 +599,16 @@ message AnnotateImageResponse {
   ImageAnnotationContext context = 21;
 }
 
+// Response to a single file annotation request. A file may contain one or more
+// images, which individually have their own responses.
+message AnnotateFileResponse {
+  // Information about the file for which this response is generated.
+  InputConfig input_config = 1;
+
+  // Individual responses to images found within the file.
+  repeated AnnotateImageResponse responses = 2;
+}
+
 // Multiple image annotation requests are batched into a single service call.
 message BatchAnnotateImagesRequest {
   // Individual image annotation requests for this batch.

--- a/src/v1p2beta1/doc/google/cloud/vision/v1p2beta1/doc_image_annotator.js
+++ b/src/v1p2beta1/doc/google/cloud/vision/v1p2beta1/doc_image_annotator.js
@@ -924,6 +924,28 @@ var AnnotateImageResponse = {
 };
 
 /**
+ * Response to a single file annotation request. A file may contain one or more
+ * images, which individually have their own responses.
+ *
+ * @property {Object} inputConfig
+ *   Information about the file for which this response is generated.
+ *
+ *   This object should have the same structure as [InputConfig]{@link google.cloud.vision.v1p2beta1.InputConfig}
+ *
+ * @property {Object[]} responses
+ *   Individual responses to images found within the file.
+ *
+ *   This object should have the same structure as [AnnotateImageResponse]{@link google.cloud.vision.v1p2beta1.AnnotateImageResponse}
+ *
+ * @typedef AnnotateFileResponse
+ * @memberof google.cloud.vision.v1p2beta1
+ * @see [google.cloud.vision.v1p2beta1.AnnotateFileResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/vision/v1p2beta1/image_annotator.proto}
+ */
+var AnnotateFileResponse = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
  * Multiple image annotation requests are batched into a single service call.
  *
  * @property {Object[]} requests


### PR DESCRIPTION
This update to the GAPIC code contains just a proto change and no changes to the code. The added message type will be used in samples (it's an actual type that will be stored in GCS, as API owners explained).

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
