### PR TITLE
feat: regenerate GAPIC v1p2beta1 code

### DIFF
--- a/protos/google/cloud/vision/v1p2beta1/geometry.proto
+++ b/protos/google/cloud/vision/v1p2beta1/geometry.proto
@@ -33,10 +33,24 @@ message Vertex {
   int32 y = 2;
 }
 
+// A vertex represents a 2D point in the image.
+// NOTE: the normalized vertex coordinates are relative to the original image
+// and range from 0 to 1.
+message NormalizedVertex {
+  // X coordinate.
+  float x = 1;
+
+  // Y coordinate.
+  float y = 2;
+}
+
 // A bounding polygon for the detected image annotation.
 message BoundingPoly {
   // The bounding polygon vertices.
   repeated Vertex vertices = 1;
+
+  // The bounding polygon normalized vertices.
+  repeated NormalizedVertex normalized_vertices = 2;
 }
 
 // A 3D position in the image, used primarily for Face detection landmarks.

--- a/protos/google/cloud/vision/v1p2beta1/image_annotator.proto
+++ b/protos/google/cloud/vision/v1p2beta1/image_annotator.proto
@@ -510,7 +510,7 @@ message WebDetectionParams {
 
 // Image context and/or feature-specific parameters.
 message ImageContext {
-  // lat/long rectangle that specifies the location of the image.
+  // Not used.
   LatLongRect lat_long_rect = 1;
 
   // List of languages to use for TEXT_DETECTION. In most cases, an empty value

--- a/protos/google/cloud/vision/v1p2beta1/web_detection.proto
+++ b/protos/google/cloud/vision/v1p2beta1/web_detection.proto
@@ -100,7 +100,6 @@ message WebDetection {
   // The visually similar image results.
   repeated WebImage visually_similar_images = 6;
 
-  // The service's best guess as to the topic of the request image.
-  // Inferred from similar images on the open web.
+  // Best guess text labels for the request image.
   repeated WebLabel best_guess_labels = 8;
 }

--- a/src/v1p2beta1/doc/google/cloud/vision/v1p2beta1/doc_geometry.js
+++ b/src/v1p2beta1/doc/google/cloud/vision/v1p2beta1/doc_geometry.js
@@ -34,12 +34,36 @@ var Vertex = {
 };
 
 /**
+ * A vertex represents a 2D point in the image.
+ * NOTE: the normalized vertex coordinates are relative to the original image
+ * and range from 0 to 1.
+ *
+ * @property {number} x
+ *   X coordinate.
+ *
+ * @property {number} y
+ *   Y coordinate.
+ *
+ * @typedef NormalizedVertex
+ * @memberof google.cloud.vision.v1p2beta1
+ * @see [google.cloud.vision.v1p2beta1.NormalizedVertex definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/vision/v1p2beta1/geometry.proto}
+ */
+var NormalizedVertex = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
  * A bounding polygon for the detected image annotation.
  *
  * @property {Object[]} vertices
  *   The bounding polygon vertices.
  *
  *   This object should have the same structure as [Vertex]{@link google.cloud.vision.v1p2beta1.Vertex}
+ *
+ * @property {Object[]} normalizedVertices
+ *   The bounding polygon normalized vertices.
+ *
+ *   This object should have the same structure as [NormalizedVertex]{@link google.cloud.vision.v1p2beta1.NormalizedVertex}
  *
  * @typedef BoundingPoly
  * @memberof google.cloud.vision.v1p2beta1

--- a/src/v1p2beta1/doc/google/cloud/vision/v1p2beta1/doc_image_annotator.js
+++ b/src/v1p2beta1/doc/google/cloud/vision/v1p2beta1/doc_image_annotator.js
@@ -768,7 +768,7 @@ var WebDetectionParams = {
  * Image context and/or feature-specific parameters.
  *
  * @property {Object} latLongRect
- *   lat/long rectangle that specifies the location of the image.
+ *   Not used.
  *
  *   This object should have the same structure as [LatLongRect]{@link google.cloud.vision.v1p2beta1.LatLongRect}
  *

--- a/src/v1p2beta1/doc/google/cloud/vision/v1p2beta1/doc_web_detection.js
+++ b/src/v1p2beta1/doc/google/cloud/vision/v1p2beta1/doc_web_detection.js
@@ -47,8 +47,7 @@
  *   This object should have the same structure as [WebImage]{@link google.cloud.vision.v1p2beta1.WebImage}
  *
  * @property {Object[]} bestGuessLabels
- *   The service's best guess as to the topic of the request image.
- *   Inferred from similar images on the open web.
+ *   Best guess text labels for the request image.
  *
  *   This object should have the same structure as [WebLabel]{@link google.cloud.vision.v1p2beta1.WebLabel}
  *


### PR DESCRIPTION
One more update for the generated code for `v1p2beta1` endpoint. We'll wait for samples, then release it. 

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
