### PR TITLE
chore: bump version to 0.19.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/vision",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/vision",
   "description": "Google Cloud Vision API client for Node.js",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "license": "Apache-2.0",
   "author": "Google Inc",
   "engines": {

--- a/samples/package-lock.json
+++ b/samples/package-lock.json
@@ -303,7 +303,7 @@
       }
     },
     "@google-cloud/vision": {
-      "version": "0.18.0",
+      "version": "0.19.0",
       "requires": {
         "@google-cloud/common": "0.17.0",
         "async": "2.6.0",

--- a/samples/package.json
+++ b/samples/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@google-cloud/storage": "^1.5.2",
-    "@google-cloud/vision": "0.18.0",
+    "@google-cloud/vision": "0.19.0",
     "async": "2.5.0",
     "natural": "0.5.4",
     "redis": "2.8.0",


### PR DESCRIPTION
Releasing v0.19.0.

---

## Features

This is a minor release that updates `v1p2beta1` code and adds a new sample of scanning the `pdf` file. The default endpoint is still `v1`, and there are no incompatible changes.

---

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
