### PR TITLE
refactor: use protobufjs library to load proto file

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -23,6 +23,23 @@ const promisify = require('@google-cloud/common').util.promisify;
 
 const gax = require('google-gax');
 
+/**
+ * An enumeration of the supported types of feature detection.
+ */
+const features = {
+  TYPE_UNSPECIFIED: 0,
+  FACE_DETECTION: 1,
+  LANDMARK_DETECTION: 2,
+  LOGO_DETECTION: 3,
+  LABEL_DETECTION: 4,
+  TEXT_DETECTION: 5,
+  DOCUMENT_TEXT_DETECTION: 11,
+  SAFE_SEARCH_DETECTION: 6,
+  IMAGE_PROPERTIES: 7,
+  CROP_HINTS: 9,
+  WEB_DETECTION: 10
+};
+
 /*!
  * Convert non-object request forms into a correctly-formatted object.
  *
@@ -242,17 +259,6 @@ module.exports = apiVersion => {
       });
     });
   });
-
-  // Get a list of features available on the API. Although we could iterate over
-  // them and create single-feature methods for each dynamically, for
-  // documentation purpose, we manually list all the single-feature methods
-  // below.
-  const features = gax
-    .grpc()
-    .loadProto(
-      path.join(__dirname, '..', 'protos'),
-      `google/cloud/vision/${apiVersion}/image_annotator.proto`
-    ).google.cloud.vision[apiVersion].Feature.Type.values;
 
   /**
    * Annotate a single image with face detection.

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -20,25 +20,9 @@ const fs = require('fs');
 const is = require('is');
 const path = require('path');
 const promisify = require('@google-cloud/common').util.promisify;
+const protobuf = require('protobufjs');
 
 const gax = require('google-gax');
-
-/**
- * An enumeration of the supported types of feature detection.
- */
-const features = {
-  TYPE_UNSPECIFIED: 0,
-  FACE_DETECTION: 1,
-  LANDMARK_DETECTION: 2,
-  LOGO_DETECTION: 3,
-  LABEL_DETECTION: 4,
-  TEXT_DETECTION: 5,
-  DOCUMENT_TEXT_DETECTION: 11,
-  SAFE_SEARCH_DETECTION: 6,
-  IMAGE_PROPERTIES: 7,
-  CROP_HINTS: 9,
-  WEB_DETECTION: 10
-};
 
 /*!
  * Convert non-object request forms into a correctly-formatted object.
@@ -259,6 +243,20 @@ module.exports = apiVersion => {
       });
     });
   });
+
+  let protoFilesRoot = new gax.grpc.GoogleProtoFilesRoot();
+  protoFilesRoot = protobuf.loadSync(
+    path.join(
+      __dirname,
+      '..',
+      'protos',
+      `google/cloud/vision/${apiVersion}/image_annotator.proto`
+    ),
+    protoFilesRoot
+  );
+  const features = protoFilesRoot.lookup(
+    `google.cloud.vision.${apiVersion}.Feature.Type`
+  ).values;
 
   /**
    * Annotate a single image with face detection.


### PR DESCRIPTION
The `grpc` module is moving towards removing its dependency on `protobufjs` in favor of introducing a separate module for creating package definitions from Protobuf files. As of right now the package definitions contain just enough information to instantiate a gRPC client, and so does not contain enumeration values such as `google.cloud.vision.v1.Feature`.

~~The change in this PR is in preparation of that -- it removes the loading of a proto file that is done to get the enumeration of supported feature detection types. I figured that since the fields on this object were already hardcoded in the file, that the enum itself can defined in this file as well.~~

The goal here is ultimately to stop depending on gRPC to load Protobuf files, so if anyone wants to advocate any alternative solutions ~~(such as explicitly depending on the `protobufjs` module to load this proto file)~~ I'm open to implementing it as part of this PR.

Edit: I see that the library already has a dependency on `protobufjs` so I've updated the PR to use that to load the proto file instead of hardcoding the enum.