### PR TITLE
fix: npm link ../ before npm install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,8 +102,8 @@ jobs:
           name: Link the module being tested to the samples.
           command: |
             cd samples/
-            npm install
             npm link ../
+            npm install
           environment:
             NPM_CONFIG_PREFIX: /home/node/.npm-global
       - run:


### PR DESCRIPTION
npm link needs to be before install, otherwise version bumps will not work