### PR TITLE
[NOT READY] Samples demonstrating Product Search (v1p3beta1)

### DIFF
--- a/samples/package-lock.json
+++ b/samples/package-lock.json
@@ -16,18 +16,18 @@
       "integrity": "sha512-oWqTnIGXW3k72UFidXzW0ONlO7hnO9x02S/QReJ7NBGeiBH9cUHY9+EfV6C8PXC6YJH++WrliEq03wMSJGNZFg==",
       "dev": true,
       "requires": {
-        "babel-plugin-check-es2015-constants": "^6.8.0",
-        "babel-plugin-syntax-trailing-function-commas": "^6.20.0",
-        "babel-plugin-transform-async-to-generator": "^6.16.0",
-        "babel-plugin-transform-es2015-destructuring": "^6.19.0",
-        "babel-plugin-transform-es2015-function-name": "^6.9.0",
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.18.0",
-        "babel-plugin-transform-es2015-parameters": "^6.21.0",
-        "babel-plugin-transform-es2015-spread": "^6.8.0",
-        "babel-plugin-transform-es2015-sticky-regex": "^6.8.0",
-        "babel-plugin-transform-es2015-unicode-regex": "^6.11.0",
-        "babel-plugin-transform-exponentiation-operator": "^6.8.0",
-        "package-hash": "^1.2.0"
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+        "babel-plugin-transform-async-to-generator": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "6.24.1",
+        "package-hash": "1.2.0"
       },
       "dependencies": {
         "md5-hex": {
@@ -36,7 +36,7 @@
           "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
           "dev": true,
           "requires": {
-            "md5-o-matic": "^0.1.1"
+            "md5-o-matic": "0.1.1"
           }
         },
         "package-hash": {
@@ -45,7 +45,7 @@
           "integrity": "sha1-AD5WzVe3NqbtYRTMK4FUJnJ3DkQ=",
           "dev": true,
           "requires": {
-            "md5-hex": "^1.3.0"
+            "md5-hex": "1.3.0"
           }
         }
       }
@@ -56,8 +56,8 @@
       "integrity": "sha1-ze0RlqjY2TgaUJJAq5LpGl7Aafc=",
       "dev": true,
       "requires": {
-        "@ava/babel-plugin-throws-helper": "^2.0.0",
-        "babel-plugin-espower": "^2.3.2"
+        "@ava/babel-plugin-throws-helper": "2.0.0",
+        "babel-plugin-espower": "2.4.0"
       }
     },
     "@ava/write-file-atomic": {
@@ -66,9 +66,9 @@
       "integrity": "sha512-BTNB3nGbEfJT+69wuqXFr/bQH7Vr7ihx2xGOMNqPgDGhwspoZhiWumDDZNjBy7AScmqS5CELIOGtPVXESyrnDA==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "slide": "^1.1.5"
+        "graceful-fs": "4.1.11",
+        "imurmurhash": "0.1.4",
+        "slide": "1.1.6"
       }
     },
     "@concordance/react": {
@@ -77,28 +77,39 @@
       "integrity": "sha512-htrsRaQX8Iixlsek8zQU7tE8wcsTQJ5UhZkSPEA8slCDAisKpC/2VgU/ucPn32M5/LjGGXRaUEKvEw1Wiuu4zQ==",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.1"
+        "arrify": "1.0.1"
       }
     },
     "@google-cloud/common": {
-      "version": "0.18.9",
-      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.18.9.tgz",
-      "integrity": "sha512-P5jtyfOCF84fzVcT/36XKARRrbCOqozYBliDd7btQ96GuEqKzjPVjxeE4EzdeRQ8QChBpHLrbONsU63Jprw73A==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.20.3.tgz",
+      "integrity": "sha512-jt8/R4EqDTQccv5WA9AEaS65llM5+mlxsuWu57G5Os8HTIpgPbcsOVMUeIvmTrBuPUYSoRIMW8d/pvv/95n0+g==",
       "requires": {
-        "@types/duplexify": "^3.5.0",
-        "@types/request": "^2.47.0",
-        "arrify": "^1.0.1",
-        "axios": "^0.18.0",
-        "duplexify": "^3.5.4",
-        "ent": "^2.2.0",
-        "extend": "^3.0.1",
-        "google-auth-library": "^1.4.0",
-        "is": "^3.2.1",
-        "pify": "^3.0.0",
-        "request": "^2.85.0",
-        "retry-request": "^3.3.1",
-        "split-array-stream": "^2.0.0",
-        "stream-events": "^1.0.4"
+        "@types/duplexify": "3.5.0",
+        "@types/request": "2.47.1",
+        "arrify": "1.0.1",
+        "axios": "0.18.0",
+        "duplexify": "3.6.0",
+        "ent": "2.2.0",
+        "extend": "3.0.1",
+        "google-auth-library": "1.6.1",
+        "is": "3.2.1",
+        "pify": "3.0.0",
+        "request": "2.87.0",
+        "retry-request": "4.0.0",
+        "split-array-stream": "2.0.0",
+        "stream-events": "1.0.4",
+        "through2": "2.0.3"
+      },
+      "dependencies": {
+        "retry-request": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-4.0.0.tgz",
+          "integrity": "sha512-S4HNLaWcMP6r8E4TMH52Y7/pM8uNayOcTDDQNBwsCccL1uI+Ol2TljxRDPzaNfbhOB30+XWP5NnZkB3LiJxi1w==",
+          "requires": {
+            "through2": "2.0.3"
+          }
+        }
       }
     },
     "@google-cloud/nodejs-repo-tools": {
@@ -115,7 +126,7 @@
         "lodash": "4.17.5",
         "nyc": "11.7.2",
         "proxyquire": "1.8.0",
-        "semver": "^5.5.0",
+        "semver": "5.5.0",
         "sinon": "6.0.1",
         "string": "3.3.3",
         "supertest": "3.1.0",
@@ -141,9 +152,9 @@
           "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
           "dev": true,
           "requires": {
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "wrap-ansi": "2.1.0"
           }
         },
         "find-up": {
@@ -152,7 +163,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -167,8 +178,8 @@
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
           }
         },
         "lodash": {
@@ -183,9 +194,9 @@
           "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "dev": true,
           "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
           }
         },
         "p-limit": {
@@ -194,7 +205,7 @@
           "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "dev": true,
           "requires": {
-            "p-try": "^1.0.0"
+            "p-try": "1.0.0"
           }
         },
         "p-locate": {
@@ -203,7 +214,7 @@
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
-            "p-limit": "^1.1.0"
+            "p-limit": "1.3.0"
           }
         },
         "p-try": {
@@ -218,8 +229,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -228,7 +239,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         },
         "yargs": {
@@ -237,18 +248,18 @@
           "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
           "dev": true,
           "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.1.1",
-            "find-up": "^2.1.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^9.0.2"
+            "cliui": "4.1.0",
+            "decamelize": "1.2.0",
+            "find-up": "2.1.0",
+            "get-caller-file": "1.0.3",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "9.0.2"
           },
           "dependencies": {
             "yargs-parser": {
@@ -257,7 +268,7 @@
               "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
               "dev": true,
               "requires": {
-                "camelcase": "^4.1.0"
+                "camelcase": "4.1.0"
               }
             }
           }
@@ -270,27 +281,27 @@
       "integrity": "sha512-QaAxzCkbhspwajoaEnT0GcnQcpjPRcBrHYuQsXtD05BtOJgVnHCLXSsfUiRdU0nVpK+Thp7+sTkQ0fvk5PanKg==",
       "dev": true,
       "requires": {
-        "@google-cloud/common": "^0.17.0",
-        "arrify": "^1.0.0",
-        "async": "^2.0.1",
-        "compressible": "^2.0.12",
-        "concat-stream": "^1.5.0",
-        "create-error-class": "^3.0.2",
-        "duplexify": "^3.5.0",
-        "extend": "^3.0.0",
-        "gcs-resumable-upload": "^0.10.2",
-        "hash-stream-validation": "^0.2.1",
-        "is": "^3.0.1",
-        "mime": "^2.2.0",
-        "mime-types": "^2.0.8",
-        "once": "^1.3.1",
-        "pumpify": "^1.5.1",
-        "request": "^2.85.0",
-        "safe-buffer": "^5.1.1",
-        "snakeize": "^0.1.0",
-        "stream-events": "^1.0.1",
-        "through2": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
+        "@google-cloud/common": "0.17.0",
+        "arrify": "1.0.1",
+        "async": "2.6.1",
+        "compressible": "2.0.14",
+        "concat-stream": "1.6.2",
+        "create-error-class": "3.0.2",
+        "duplexify": "3.6.0",
+        "extend": "3.0.1",
+        "gcs-resumable-upload": "0.10.2",
+        "hash-stream-validation": "0.2.1",
+        "is": "3.2.1",
+        "mime": "2.3.1",
+        "mime-types": "2.1.18",
+        "once": "1.4.0",
+        "pumpify": "1.5.1",
+        "request": "2.87.0",
+        "safe-buffer": "5.1.2",
+        "snakeize": "0.1.0",
+        "stream-events": "1.0.4",
+        "through2": "2.0.3",
+        "xdg-basedir": "3.0.0"
       },
       "dependencies": {
         "@google-cloud/common": {
@@ -299,24 +310,24 @@
           "integrity": "sha512-HRZLSU762E6HaKoGfJGa8W95yRjb9rY7LePhjaHK9ILAnFacMuUGVamDbTHu1csZomm1g3tZTtXfX/aAhtie/Q==",
           "dev": true,
           "requires": {
-            "array-uniq": "^1.0.3",
-            "arrify": "^1.0.1",
-            "concat-stream": "^1.6.0",
-            "create-error-class": "^3.0.2",
-            "duplexify": "^3.5.0",
-            "ent": "^2.2.0",
-            "extend": "^3.0.1",
-            "google-auto-auth": "^0.10.0",
-            "is": "^3.2.0",
+            "array-uniq": "1.0.3",
+            "arrify": "1.0.1",
+            "concat-stream": "1.6.2",
+            "create-error-class": "3.0.2",
+            "duplexify": "3.6.0",
+            "ent": "2.2.0",
+            "extend": "3.0.1",
+            "google-auto-auth": "0.10.1",
+            "is": "3.2.1",
             "log-driver": "1.2.7",
-            "methmeth": "^1.1.0",
-            "modelo": "^4.2.0",
-            "request": "^2.79.0",
-            "retry-request": "^3.0.0",
-            "split-array-stream": "^1.0.0",
-            "stream-events": "^1.0.1",
-            "string-format-obj": "^1.1.0",
-            "through2": "^2.0.3"
+            "methmeth": "1.1.0",
+            "modelo": "4.2.3",
+            "request": "2.87.0",
+            "retry-request": "3.3.2",
+            "split-array-stream": "1.0.3",
+            "stream-events": "1.0.4",
+            "string-format-obj": "1.1.1",
+            "through2": "2.0.3"
           }
         },
         "split-array-stream": {
@@ -325,25 +336,22 @@
           "integrity": "sha1-0rdajl4Ngk1S/eyLgiWDncLjXfo=",
           "dev": true,
           "requires": {
-            "async": "^2.4.0",
-            "is-stream-ended": "^0.1.0"
+            "async": "2.6.1",
+            "is-stream-ended": "0.1.4"
           }
         }
       }
     },
     "@google-cloud/vision": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/vision/-/vision-0.20.0.tgz",
-      "integrity": "sha512-DViOFwGYw/H8RhgW+oHAc54lHt9dBBM7aZiF73gBYKrs/bRGhf6PQHMDJ/xuWcxba+12xcONBMFLwCq4U5Ux6w==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/vision/-/vision-0.21.0.tgz",
+      "integrity": "sha512-DCiJMtReGeJUP0YWaek0B6olvB16CVsLbB2J1WQOeeQMYTHGCEFxFS/othifMYAtJMrgKVnEMZ712v80dZc7sg==",
       "requires": {
-        "@google-cloud/common": "^0.18.2",
-        "async": "^2.0.1",
-        "extend": "^3.0.0",
-        "google-gax": "^0.16.0",
-        "google-proto-files": "^0.15.0",
-        "is": "^3.0.1",
-        "lodash.merge": "^4.6.0",
-        "protobufjs": "^6.8.6"
+        "@google-cloud/common": "0.20.3",
+        "google-gax": "0.17.1",
+        "is": "3.2.1",
+        "lodash.merge": "4.6.1",
+        "protobufjs": "6.8.8"
       }
     },
     "@ladjs/time-require": {
@@ -352,10 +360,10 @@
       "integrity": "sha512-weIbJqTMfQ4r1YX85u54DKfjLZs2jwn1XZ6tIOP/pFgMwhIN5BAtaCp/1wn9DzyLsDR9tW0R2NIePcVJ45ivQQ==",
       "dev": true,
       "requires": {
-        "chalk": "^0.4.0",
-        "date-time": "^0.1.1",
-        "pretty-ms": "^0.2.1",
-        "text-table": "^0.2.0"
+        "chalk": "0.4.0",
+        "date-time": "0.1.1",
+        "pretty-ms": "0.2.2",
+        "text-table": "0.2.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -370,9 +378,9 @@
           "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
           "dev": true,
           "requires": {
-            "ansi-styles": "~1.0.0",
-            "has-color": "~0.1.0",
-            "strip-ansi": "~0.1.0"
+            "ansi-styles": "1.0.0",
+            "has-color": "0.1.7",
+            "strip-ansi": "0.1.1"
           }
         },
         "pretty-ms": {
@@ -381,7 +389,7 @@
           "integrity": "sha1-2oeaaC/zOjcBEEbxPWJ/Z8c7hPY=",
           "dev": true,
           "requires": {
-            "parse-ms": "^0.1.0"
+            "parse-ms": "0.1.2"
           }
         },
         "strip-ansi": {
@@ -397,8 +405,8 @@
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
       "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
       "requires": {
-        "call-me-maybe": "^1.0.1",
-        "glob-to-regexp": "^0.3.0"
+        "call-me-maybe": "1.0.1",
+        "glob-to-regexp": "0.3.0"
       }
     },
     "@nodelib/fs.stat": {
@@ -431,8 +439,8 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
       "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
       "requires": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "1.1.2",
+        "@protobufjs/inquire": "1.1.0"
       }
     },
     "@protobufjs/float": {
@@ -485,7 +493,7 @@
       "resolved": "https://registry.npmjs.org/@types/duplexify/-/duplexify-3.5.0.tgz",
       "integrity": "sha512-+aZCCdxuR/Q6n58CBkXyqGqimIqpYUcFLfBXagXv7e9TdJUevqkKhzopBuRz3RB064sQxnJnhttHOkK/O93Ouw==",
       "requires": {
-        "@types/node": "*"
+        "@types/node": "10.5.2"
       }
     },
     "@types/form-data": {
@@ -493,13 +501,13 @@
       "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
       "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
       "requires": {
-        "@types/node": "*"
+        "@types/node": "10.5.2"
       }
     },
     "@types/long": {
-      "version": "3.0.32",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-3.0.32.tgz",
-      "integrity": "sha512-ZXyOOm83p7X8p3s0IYM3VeueNmHpkk/yMlP8CLeOnEcu6hIwPH7YjZBvhQkR0ZFS2DqZAxKtJ/M5fcuv3OU5BA=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q=="
     },
     "@types/node": {
       "version": "10.5.2",
@@ -511,10 +519,10 @@
       "resolved": "https://registry.npmjs.org/@types/request/-/request-2.47.1.tgz",
       "integrity": "sha512-TV3XLvDjQbIeVxJ1Z3oCTDk/KuYwwcNKVwz2YaT0F5u86Prgc4syDAp6P96rkTQQ4bIdh+VswQIC9zS6NjY7/g==",
       "requires": {
-        "@types/caseless": "*",
-        "@types/form-data": "*",
-        "@types/node": "*",
-        "@types/tough-cookie": "*"
+        "@types/caseless": "0.12.1",
+        "@types/form-data": "2.2.1",
+        "@types/node": "10.5.2",
+        "@types/tough-cookie": "2.3.3"
       }
     },
     "@types/tough-cookie": {
@@ -542,10 +550,10 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
+        "co": "4.6.0",
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
     },
     "align-text": {
@@ -554,9 +562,9 @@
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
       },
       "dependencies": {
         "kind-of": {
@@ -565,7 +573,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -582,7 +590,7 @@
       "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
       "dev": true,
       "requires": {
-        "string-width": "^2.0.0"
+        "string-width": "2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -603,8 +611,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -613,7 +621,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -635,7 +643,7 @@
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "requires": {
-        "color-convert": "^1.9.0"
+        "color-convert": "1.9.2"
       }
     },
     "anymatch": {
@@ -644,8 +652,8 @@
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "requires": {
-        "micromatch": "^2.1.5",
-        "normalize-path": "^2.0.0"
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -654,7 +662,7 @@
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.0.1"
+            "arr-flatten": "1.1.0"
           }
         },
         "array-unique": {
@@ -669,9 +677,9 @@
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
           "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.2"
           }
         },
         "expand-brackets": {
@@ -680,7 +688,7 @@
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
           "requires": {
-            "is-posix-bracket": "^0.1.0"
+            "is-posix-bracket": "0.1.1"
           }
         },
         "extglob": {
@@ -689,7 +697,7 @@
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         },
         "is-extglob": {
@@ -704,7 +712,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         },
         "kind-of": {
@@ -713,7 +721,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         },
         "micromatch": {
@@ -722,19 +730,19 @@
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
           "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
           }
         }
       }
@@ -744,7 +752,7 @@
       "resolved": "https://registry.npmjs.org/apparatus/-/apparatus-0.0.10.tgz",
       "integrity": "sha512-KLy/ugo33KZA7nugtQ7O0E1c8kQ52N3IvD/XgIh4w/Nr28ypfkwDfA67F1ev4N1m5D+BOk1+b2dEJDfpj/VvZg==",
       "requires": {
-        "sylvester": ">= 0.0.8"
+        "sylvester": "0.0.12"
       }
     },
     "argparse": {
@@ -753,7 +761,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "arr-diff": {
@@ -799,7 +807,7 @@
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "requires": {
-        "array-uniq": "^1.0.1"
+        "array-uniq": "1.0.3"
       }
     },
     "array-uniq": {
@@ -822,8 +830,8 @@
       "resolved": "https://registry.npmjs.org/ascli/-/ascli-1.0.1.tgz",
       "integrity": "sha1-vPpZdKYvGOgcq660lzKrSoj5Brw=",
       "requires": {
-        "colour": "~0.7.1",
-        "optjs": "~3.2.2"
+        "colour": "0.7.1",
+        "optjs": "3.2.2"
       }
     },
     "asn1": {
@@ -846,7 +854,7 @@
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
       "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "requires": {
-        "lodash": "^4.17.10"
+        "lodash": "4.17.10"
       }
     },
     "async-each": {
@@ -877,89 +885,89 @@
       "integrity": "sha512-4lGNJCf6xL8SvsKVEKxEE46se7JAUIAZoKHw9itTQuwcsydhpAMkBs5gOOiWiwt0JKNIuXWc2/r4r8ZdcNrBEw==",
       "dev": true,
       "requires": {
-        "@ava/babel-preset-stage-4": "^1.1.0",
-        "@ava/babel-preset-transform-test-files": "^3.0.0",
-        "@ava/write-file-atomic": "^2.2.0",
-        "@concordance/react": "^1.0.0",
-        "@ladjs/time-require": "^0.1.4",
-        "ansi-escapes": "^3.0.0",
-        "ansi-styles": "^3.1.0",
-        "arr-flatten": "^1.0.1",
-        "array-union": "^1.0.1",
-        "array-uniq": "^1.0.2",
-        "arrify": "^1.0.0",
-        "auto-bind": "^1.1.0",
-        "ava-init": "^0.2.0",
-        "babel-core": "^6.17.0",
-        "babel-generator": "^6.26.0",
-        "babel-plugin-syntax-object-rest-spread": "^6.13.0",
-        "bluebird": "^3.0.0",
-        "caching-transform": "^1.0.0",
-        "chalk": "^2.0.1",
-        "chokidar": "^1.4.2",
-        "clean-stack": "^1.1.1",
-        "clean-yaml-object": "^0.1.0",
-        "cli-cursor": "^2.1.0",
-        "cli-spinners": "^1.0.0",
-        "cli-truncate": "^1.0.0",
-        "co-with-promise": "^4.6.0",
-        "code-excerpt": "^2.1.1",
-        "common-path-prefix": "^1.0.0",
-        "concordance": "^3.0.0",
-        "convert-source-map": "^1.5.1",
-        "core-assert": "^0.2.0",
-        "currently-unhandled": "^0.4.1",
-        "debug": "^3.0.1",
-        "dot-prop": "^4.1.0",
-        "empower-core": "^0.6.1",
-        "equal-length": "^1.0.0",
-        "figures": "^2.0.0",
-        "find-cache-dir": "^1.0.0",
-        "fn-name": "^2.0.0",
-        "get-port": "^3.0.0",
-        "globby": "^6.0.0",
-        "has-flag": "^2.0.0",
-        "hullabaloo-config-manager": "^1.1.0",
-        "ignore-by-default": "^1.0.0",
-        "import-local": "^0.1.1",
-        "indent-string": "^3.0.0",
-        "is-ci": "^1.0.7",
-        "is-generator-fn": "^1.0.0",
-        "is-obj": "^1.0.0",
-        "is-observable": "^1.0.0",
-        "is-promise": "^2.1.0",
-        "last-line-stream": "^1.0.0",
-        "lodash.clonedeepwith": "^4.5.0",
-        "lodash.debounce": "^4.0.3",
-        "lodash.difference": "^4.3.0",
-        "lodash.flatten": "^4.2.0",
-        "loud-rejection": "^1.2.0",
-        "make-dir": "^1.0.0",
-        "matcher": "^1.0.0",
-        "md5-hex": "^2.0.0",
-        "meow": "^3.7.0",
-        "ms": "^2.0.0",
-        "multimatch": "^2.1.0",
-        "observable-to-promise": "^0.5.0",
-        "option-chain": "^1.0.0",
-        "package-hash": "^2.0.0",
-        "pkg-conf": "^2.0.0",
-        "plur": "^2.0.0",
-        "pretty-ms": "^3.0.0",
-        "require-precompiled": "^0.1.0",
-        "resolve-cwd": "^2.0.0",
-        "safe-buffer": "^5.1.1",
-        "semver": "^5.4.1",
-        "slash": "^1.0.0",
-        "source-map-support": "^0.5.0",
-        "stack-utils": "^1.0.1",
-        "strip-ansi": "^4.0.0",
-        "strip-bom-buf": "^1.0.0",
-        "supertap": "^1.0.0",
-        "supports-color": "^5.0.0",
-        "trim-off-newlines": "^1.0.1",
-        "unique-temp-dir": "^1.0.0",
-        "update-notifier": "^2.3.0"
+        "@ava/babel-preset-stage-4": "1.1.0",
+        "@ava/babel-preset-transform-test-files": "3.0.0",
+        "@ava/write-file-atomic": "2.2.0",
+        "@concordance/react": "1.0.0",
+        "@ladjs/time-require": "0.1.4",
+        "ansi-escapes": "3.1.0",
+        "ansi-styles": "3.2.1",
+        "arr-flatten": "1.1.0",
+        "array-union": "1.0.2",
+        "array-uniq": "1.0.3",
+        "arrify": "1.0.1",
+        "auto-bind": "1.2.1",
+        "ava-init": "0.2.1",
+        "babel-core": "6.26.3",
+        "babel-generator": "6.26.1",
+        "babel-plugin-syntax-object-rest-spread": "6.13.0",
+        "bluebird": "3.5.1",
+        "caching-transform": "1.0.1",
+        "chalk": "2.4.1",
+        "chokidar": "1.7.0",
+        "clean-stack": "1.3.0",
+        "clean-yaml-object": "0.1.0",
+        "cli-cursor": "2.1.0",
+        "cli-spinners": "1.3.1",
+        "cli-truncate": "1.1.0",
+        "co-with-promise": "4.6.0",
+        "code-excerpt": "2.1.1",
+        "common-path-prefix": "1.0.0",
+        "concordance": "3.0.0",
+        "convert-source-map": "1.5.1",
+        "core-assert": "0.2.1",
+        "currently-unhandled": "0.4.1",
+        "debug": "3.1.0",
+        "dot-prop": "4.2.0",
+        "empower-core": "0.6.2",
+        "equal-length": "1.0.1",
+        "figures": "2.0.0",
+        "find-cache-dir": "1.0.0",
+        "fn-name": "2.0.1",
+        "get-port": "3.2.0",
+        "globby": "6.1.0",
+        "has-flag": "2.0.0",
+        "hullabaloo-config-manager": "1.1.1",
+        "ignore-by-default": "1.0.1",
+        "import-local": "0.1.1",
+        "indent-string": "3.2.0",
+        "is-ci": "1.1.0",
+        "is-generator-fn": "1.0.0",
+        "is-obj": "1.0.1",
+        "is-observable": "1.1.0",
+        "is-promise": "2.1.0",
+        "last-line-stream": "1.0.0",
+        "lodash.clonedeepwith": "4.5.0",
+        "lodash.debounce": "4.0.8",
+        "lodash.difference": "4.5.0",
+        "lodash.flatten": "4.4.0",
+        "loud-rejection": "1.6.0",
+        "make-dir": "1.3.0",
+        "matcher": "1.1.1",
+        "md5-hex": "2.0.0",
+        "meow": "3.7.0",
+        "ms": "2.0.0",
+        "multimatch": "2.1.0",
+        "observable-to-promise": "0.5.0",
+        "option-chain": "1.0.0",
+        "package-hash": "2.0.0",
+        "pkg-conf": "2.1.0",
+        "plur": "2.1.2",
+        "pretty-ms": "3.2.0",
+        "require-precompiled": "0.1.0",
+        "resolve-cwd": "2.0.0",
+        "safe-buffer": "5.1.2",
+        "semver": "5.5.0",
+        "slash": "1.0.0",
+        "source-map-support": "0.5.6",
+        "stack-utils": "1.0.1",
+        "strip-ansi": "4.0.0",
+        "strip-bom-buf": "1.0.0",
+        "supertap": "1.0.0",
+        "supports-color": "5.4.0",
+        "trim-off-newlines": "1.0.1",
+        "unique-temp-dir": "1.0.0",
+        "update-notifier": "2.5.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -975,7 +983,7 @@
           "dev": true,
           "requires": {
             "call-signature": "0.0.2",
-            "core-js": "^2.0.0"
+            "core-js": "2.5.7"
           }
         },
         "globby": {
@@ -984,11 +992,11 @@
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "dev": true,
           "requires": {
-            "array-union": "^1.0.1",
-            "glob": "^7.0.3",
-            "object-assign": "^4.0.1",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "array-union": "1.0.2",
+            "glob": "7.1.2",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "pify": {
@@ -1009,7 +1017,7 @@
           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
           "dev": true,
           "requires": {
-            "pinkie": "^2.0.0"
+            "pinkie": "2.0.4"
           }
         },
         "strip-ansi": {
@@ -1018,7 +1026,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -1029,11 +1037,11 @@
       "integrity": "sha512-lXwK5LM+2g1euDRqW1mcSX/tqzY1QU7EjKpqayFPPtNRmbSYZ8RzPO5tqluTToijmtjp2M+pNpVdbcHssC4glg==",
       "dev": true,
       "requires": {
-        "arr-exclude": "^1.0.0",
-        "execa": "^0.7.0",
-        "has-yarn": "^1.0.0",
-        "read-pkg-up": "^2.0.0",
-        "write-pkg": "^3.1.0"
+        "arr-exclude": "1.0.0",
+        "execa": "0.7.0",
+        "has-yarn": "1.0.0",
+        "read-pkg-up": "2.0.0",
+        "write-pkg": "3.2.0"
       }
     },
     "aws-sign2": {
@@ -1051,8 +1059,8 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
       "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
       "requires": {
-        "follow-redirects": "^1.3.0",
-        "is-buffer": "^1.1.5"
+        "follow-redirects": "1.5.1",
+        "is-buffer": "1.1.6"
       }
     },
     "babel-code-frame": {
@@ -1061,9 +1069,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -1078,11 +1086,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "supports-color": {
@@ -1099,25 +1107,25 @@
       "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-generator": "^6.26.0",
-        "babel-helpers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-register": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "convert-source-map": "^1.5.1",
-        "debug": "^2.6.9",
-        "json5": "^0.5.1",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.4",
-        "path-is-absolute": "^1.0.1",
-        "private": "^0.1.8",
-        "slash": "^1.0.0",
-        "source-map": "^0.5.7"
+        "babel-code-frame": "6.26.0",
+        "babel-generator": "6.26.1",
+        "babel-helpers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-register": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "convert-source-map": "1.5.1",
+        "debug": "2.6.9",
+        "json5": "0.5.1",
+        "lodash": "4.17.10",
+        "minimatch": "3.0.4",
+        "path-is-absolute": "1.0.1",
+        "private": "0.1.8",
+        "slash": "1.0.0",
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "debug": {
@@ -1137,14 +1145,14 @@
       "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
       "dev": true,
       "requires": {
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "detect-indent": "^4.0.0",
-        "jsesc": "^1.3.0",
-        "lodash": "^4.17.4",
-        "source-map": "^0.5.7",
-        "trim-right": "^1.0.1"
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.10",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
       },
       "dependencies": {
         "jsesc": {
@@ -1161,9 +1169,9 @@
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
       "dev": true,
       "requires": {
-        "babel-helper-explode-assignable-expression": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-explode-assignable-expression": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-call-delegate": {
@@ -1172,10 +1180,10 @@
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-explode-assignable-expression": {
@@ -1184,9 +1192,9 @@
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-function-name": {
@@ -1195,11 +1203,11 @@
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "dev": true,
       "requires": {
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-get-function-arity": {
@@ -1208,8 +1216,8 @@
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-hoist-variables": {
@@ -1218,8 +1226,8 @@
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-regex": {
@@ -1228,9 +1236,9 @@
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.10"
       }
     },
     "babel-helper-remap-async-to-generator": {
@@ -1239,11 +1247,11 @@
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helpers": {
@@ -1252,8 +1260,8 @@
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-messages": {
@@ -1262,7 +1270,7 @@
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-check-es2015-constants": {
@@ -1271,7 +1279,7 @@
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-espower": {
@@ -1280,13 +1288,13 @@
       "integrity": "sha512-/+SRpy7pKgTI28oEHfn1wkuM5QFAdRq8WNsOOih1dVrdV6A/WbNbRZyl0eX5eyDgtb0lOE27PeDFuCX2j8OxVg==",
       "dev": true,
       "requires": {
-        "babel-generator": "^6.1.0",
-        "babylon": "^6.1.0",
-        "call-matcher": "^1.0.0",
-        "core-js": "^2.0.0",
-        "espower-location-detector": "^1.0.0",
-        "espurify": "^1.6.0",
-        "estraverse": "^4.1.1"
+        "babel-generator": "6.26.1",
+        "babylon": "6.18.0",
+        "call-matcher": "1.0.1",
+        "core-js": "2.5.7",
+        "espower-location-detector": "1.0.0",
+        "espurify": "1.8.1",
+        "estraverse": "4.2.0"
       }
     },
     "babel-plugin-syntax-async-functions": {
@@ -1319,9 +1327,9 @@
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
       "dev": true,
       "requires": {
-        "babel-helper-remap-async-to-generator": "^6.24.1",
-        "babel-plugin-syntax-async-functions": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-remap-async-to-generator": "6.24.1",
+        "babel-plugin-syntax-async-functions": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -1330,7 +1338,7 @@
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-function-name": {
@@ -1339,9 +1347,9 @@
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
@@ -1350,10 +1358,10 @@
       "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-strict-mode": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-types": "^6.26.0"
+        "babel-plugin-transform-strict-mode": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -1362,12 +1370,12 @@
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "dev": true,
       "requires": {
-        "babel-helper-call-delegate": "^6.24.1",
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-call-delegate": "6.24.1",
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-spread": {
@@ -1376,7 +1384,7 @@
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
@@ -1385,9 +1393,9 @@
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
@@ -1396,9 +1404,9 @@
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "regexpu-core": "^2.0.0"
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "regexpu-core": "2.0.0"
       }
     },
     "babel-plugin-transform-exponentiation-operator": {
@@ -1407,9 +1415,9 @@
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
       "dev": true,
       "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-strict-mode": {
@@ -1418,8 +1426,8 @@
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-register": {
@@ -1428,13 +1436,13 @@
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "dev": true,
       "requires": {
-        "babel-core": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "home-or-tmp": "^2.0.0",
-        "lodash": "^4.17.4",
-        "mkdirp": "^0.5.1",
-        "source-map-support": "^0.4.15"
+        "babel-core": "6.26.3",
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.7",
+        "home-or-tmp": "2.0.0",
+        "lodash": "4.17.10",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.18"
       },
       "dependencies": {
         "source-map-support": {
@@ -1443,7 +1451,7 @@
           "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
           "dev": true,
           "requires": {
-            "source-map": "^0.5.6"
+            "source-map": "0.5.7"
           }
         }
       }
@@ -1454,8 +1462,8 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
+        "core-js": "2.5.7",
+        "regenerator-runtime": "0.11.1"
       }
     },
     "babel-template": {
@@ -1464,11 +1472,11 @@
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "lodash": "4.17.10"
       }
     },
     "babel-traverse": {
@@ -1477,15 +1485,15 @@
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "debug": "^2.6.8",
-        "globals": "^9.18.0",
-        "invariant": "^2.2.2",
-        "lodash": "^4.17.4"
+        "babel-code-frame": "6.26.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "debug": "2.6.9",
+        "globals": "9.18.0",
+        "invariant": "2.2.4",
+        "lodash": "4.17.10"
       },
       "dependencies": {
         "debug": {
@@ -1505,10 +1513,10 @@
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
-        "to-fast-properties": "^1.0.3"
+        "babel-runtime": "6.26.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.10",
+        "to-fast-properties": "1.0.3"
       }
     },
     "babylon": {
@@ -1527,13 +1535,13 @@
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "requires": {
-        "cache-base": "^1.0.1",
-        "class-utils": "^0.3.5",
-        "component-emitter": "^1.2.1",
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.1",
-        "mixin-deep": "^1.2.0",
-        "pascalcase": "^0.1.1"
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.2.1",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.1",
+        "pascalcase": "0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -1541,7 +1549,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -1549,7 +1557,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -1557,7 +1565,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -1565,9 +1573,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         }
       }
@@ -1578,7 +1586,7 @@
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "optional": true,
       "requires": {
-        "tweetnacl": "^0.14.3"
+        "tweetnacl": "0.14.5"
       }
     },
     "binary-extensions": {
@@ -1599,13 +1607,13 @@
       "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
       "dev": true,
       "requires": {
-        "ansi-align": "^2.0.0",
-        "camelcase": "^4.0.0",
-        "chalk": "^2.0.1",
-        "cli-boxes": "^1.0.0",
-        "string-width": "^2.0.0",
-        "term-size": "^1.2.0",
-        "widest-line": "^2.0.0"
+        "ansi-align": "2.0.0",
+        "camelcase": "4.1.0",
+        "chalk": "2.4.1",
+        "cli-boxes": "1.0.0",
+        "string-width": "2.1.1",
+        "term-size": "1.2.0",
+        "widest-line": "2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1632,8 +1640,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -1642,7 +1650,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -1652,7 +1660,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -1661,16 +1669,16 @@
       "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
       "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "requires": {
-        "arr-flatten": "^1.1.0",
-        "array-unique": "^0.3.2",
-        "extend-shallow": "^2.0.1",
-        "fill-range": "^4.0.0",
-        "isobject": "^3.0.1",
-        "repeat-element": "^1.1.2",
-        "snapdragon": "^0.8.1",
-        "snapdragon-node": "^2.0.1",
-        "split-string": "^3.0.2",
-        "to-regex": "^3.0.1"
+        "arr-flatten": "1.1.0",
+        "array-unique": "0.3.2",
+        "extend-shallow": "2.0.1",
+        "fill-range": "4.0.0",
+        "isobject": "3.0.1",
+        "repeat-element": "1.1.2",
+        "snapdragon": "0.8.2",
+        "snapdragon-node": "2.1.1",
+        "split-string": "3.1.0",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "extend-shallow": {
@@ -1678,7 +1686,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -1711,7 +1719,7 @@
       "resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-5.0.1.tgz",
       "integrity": "sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=",
       "requires": {
-        "long": "~3"
+        "long": "3.2.0"
       },
       "dependencies": {
         "long": {
@@ -1726,15 +1734,15 @@
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "requires": {
-        "collection-visit": "^1.0.0",
-        "component-emitter": "^1.2.1",
-        "get-value": "^2.0.6",
-        "has-value": "^1.0.0",
-        "isobject": "^3.0.1",
-        "set-value": "^2.0.0",
-        "to-object-path": "^0.3.0",
-        "union-value": "^1.0.0",
-        "unset-value": "^1.0.0"
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.2.1",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
       }
     },
     "cacheable-request": {
@@ -1766,9 +1774,9 @@
       "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
       "dev": true,
       "requires": {
-        "md5-hex": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "write-file-atomic": "^1.1.4"
+        "md5-hex": "1.3.0",
+        "mkdirp": "0.5.1",
+        "write-file-atomic": "1.3.4"
       },
       "dependencies": {
         "md5-hex": {
@@ -1777,7 +1785,7 @@
           "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
           "dev": true,
           "requires": {
-            "md5-o-matic": "^0.1.1"
+            "md5-o-matic": "0.1.1"
           }
         },
         "write-file-atomic": {
@@ -1786,9 +1794,9 @@
           "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "slide": "^1.1.5"
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "slide": "1.1.6"
           }
         }
       }
@@ -1799,10 +1807,10 @@
       "integrity": "sha1-UTTQd5hPcSpU2tPL9i3ijc5BbKg=",
       "dev": true,
       "requires": {
-        "core-js": "^2.0.0",
-        "deep-equal": "^1.0.0",
-        "espurify": "^1.6.0",
-        "estraverse": "^4.0.0"
+        "core-js": "2.5.7",
+        "deep-equal": "1.0.1",
+        "espurify": "1.8.1",
+        "estraverse": "4.2.0"
       }
     },
     "call-me-maybe": {
@@ -1826,8 +1834,8 @@
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "^2.0.0",
-        "map-obj": "^1.0.0"
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
       }
     },
     "canvas": {
@@ -1836,7 +1844,7 @@
       "integrity": "sha512-ElVw5Uk8PReGpzXfDg6PDa+wntnZLGWWfdSHI0Pc8GyXiFbW13drSTzWU6C4E5QylHe+FnLqI7ngMRlp3eGZIQ==",
       "optional": true,
       "requires": {
-        "nan": "^2.10.0"
+        "nan": "2.10.0"
       }
     },
     "capture-stack-trace": {
@@ -1857,8 +1865,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
       }
     },
     "chalk": {
@@ -1867,9 +1875,9 @@
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.4.0"
       }
     },
     "chokidar": {
@@ -1878,15 +1886,15 @@
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
       "requires": {
-        "anymatch": "^1.3.0",
-        "async-each": "^1.0.0",
-        "fsevents": "^1.0.0",
-        "glob-parent": "^2.0.0",
-        "inherits": "^2.0.1",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^2.0.0",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.0.0"
+        "anymatch": "1.3.2",
+        "async-each": "1.0.1",
+        "fsevents": "1.2.4",
+        "glob-parent": "2.0.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "2.0.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0"
       },
       "dependencies": {
         "glob-parent": {
@@ -1895,7 +1903,7 @@
           "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
           "dev": true,
           "requires": {
-            "is-glob": "^2.0.0"
+            "is-glob": "2.0.1"
           }
         },
         "is-extglob": {
@@ -1910,7 +1918,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         }
       }
@@ -1926,10 +1934,10 @@
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "requires": {
-        "arr-union": "^3.1.0",
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "static-extend": "^0.1.1"
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
       },
       "dependencies": {
         "define-property": {
@@ -1937,7 +1945,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -1966,7 +1974,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "^2.0.0"
+        "restore-cursor": "2.0.0"
       }
     },
     "cli-spinners": {
@@ -1981,8 +1989,8 @@
       "integrity": "sha512-bAtZo0u82gCfaAGfSNxUdTI9mNyza7D8w4CVCcaOsy7sgwDzvx6ekr6cuWJqY3UGzgnQ1+4wgENup5eIhgxEYA==",
       "dev": true,
       "requires": {
-        "slice-ansi": "^1.0.0",
-        "string-width": "^2.0.0"
+        "slice-ansi": "1.0.0",
+        "string-width": "2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -2003,8 +2011,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -2013,7 +2021,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -2023,9 +2031,9 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wrap-ansi": "^2.0.0"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wrap-ansi": "2.1.0"
       }
     },
     "clone-response": {
@@ -2034,7 +2042,7 @@
       "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
       "dev": true,
       "requires": {
-        "mimic-response": "^1.0.0"
+        "mimic-response": "1.0.1"
       }
     },
     "co": {
@@ -2048,7 +2056,7 @@
       "integrity": "sha1-QT59tvWJOmC5Qs9JLEvsk9tBWrc=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "^1.0.0"
+        "pinkie-promise": "1.0.0"
       }
     },
     "code-excerpt": {
@@ -2057,7 +2065,7 @@
       "integrity": "sha512-tJLhH3EpFm/1x7heIW0hemXJTUU5EWl2V0EIX558jp05Mt1U6DVryCgkp3l37cxqs+DNbNgxG43SkwJXpQ14Jw==",
       "dev": true,
       "requires": {
-        "convert-to-spaces": "^1.0.1"
+        "convert-to-spaces": "1.0.2"
       }
     },
     "code-point-at": {
@@ -2070,8 +2078,8 @@
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "requires": {
-        "map-visit": "^1.0.0",
-        "object-visit": "^1.0.0"
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
       }
     },
     "color-convert": {
@@ -2105,7 +2113,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "common-path-prefix": {
@@ -2131,7 +2139,7 @@
       "integrity": "sha1-MmxfUH+7BV9UEWeCuWmoG2einac=",
       "dev": true,
       "requires": {
-        "mime-db": ">= 1.34.0 < 2"
+        "mime-db": "1.35.0"
       },
       "dependencies": {
         "mime-db": {
@@ -2153,10 +2161,10 @@
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "buffer-from": "1.1.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "typedarray": "0.0.6"
       }
     },
     "concordance": {
@@ -2165,17 +2173,17 @@
       "integrity": "sha512-CZBzJ3/l5QJjlZM20WY7+5GP5pMTw+1UEbThcpMw8/rojsi5sBCiD8ZbBLtD+jYpRGAkwuKuqk108c154V9eyQ==",
       "dev": true,
       "requires": {
-        "date-time": "^2.1.0",
-        "esutils": "^2.0.2",
-        "fast-diff": "^1.1.1",
-        "function-name-support": "^0.2.0",
-        "js-string-escape": "^1.0.1",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.flattendeep": "^4.4.0",
-        "lodash.merge": "^4.6.0",
-        "md5-hex": "^2.0.0",
-        "semver": "^5.3.0",
-        "well-known-symbols": "^1.0.0"
+        "date-time": "2.1.0",
+        "esutils": "2.0.2",
+        "fast-diff": "1.1.2",
+        "function-name-support": "0.2.0",
+        "js-string-escape": "1.0.1",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.flattendeep": "4.4.0",
+        "lodash.merge": "4.6.1",
+        "md5-hex": "2.0.0",
+        "semver": "5.5.0",
+        "well-known-symbols": "1.0.0"
       },
       "dependencies": {
         "date-time": {
@@ -2184,7 +2192,7 @@
           "integrity": "sha512-/9+C44X7lot0IeiyfgJmETtRMhBidBYM2QFFIkGa0U1k+hSyY87Nw7PY3eDqpvCBm7I3WCSfPeZskW/YYq6m4g==",
           "dev": true,
           "requires": {
-            "time-zone": "^1.0.0"
+            "time-zone": "1.0.0"
           }
         }
       }
@@ -2195,12 +2203,12 @@
       "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
       "dev": true,
       "requires": {
-        "dot-prop": "^4.1.0",
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^1.0.0",
-        "unique-string": "^1.0.0",
-        "write-file-atomic": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
+        "dot-prop": "4.2.0",
+        "graceful-fs": "4.1.11",
+        "make-dir": "1.3.0",
+        "unique-string": "1.0.0",
+        "write-file-atomic": "2.3.0",
+        "xdg-basedir": "3.0.0"
       }
     },
     "convert-source-map": {
@@ -2232,8 +2240,8 @@
       "integrity": "sha1-+F4s+b/tKPdzzIs/pcW2m9wC/j8=",
       "dev": true,
       "requires": {
-        "buf-compare": "^1.0.0",
-        "is-error": "^2.2.0"
+        "buf-compare": "1.0.1",
+        "is-error": "2.2.1"
       }
     },
     "core-js": {
@@ -2252,7 +2260,7 @@
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "dev": true,
       "requires": {
-        "capture-stack-trace": "^1.0.0"
+        "capture-stack-trace": "1.0.0"
       }
     },
     "cross-spawn": {
@@ -2260,9 +2268,9 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "requires": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "lru-cache": "4.1.3",
+        "shebang-command": "1.2.0",
+        "which": "1.3.1"
       }
     },
     "crypto-random-string": {
@@ -2277,7 +2285,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "^1.0.1"
+        "array-find-index": "1.0.2"
       }
     },
     "dashdash": {
@@ -2285,7 +2293,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "date-time": {
@@ -2318,7 +2326,7 @@
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "dev": true,
       "requires": {
-        "mimic-response": "^1.0.0"
+        "mimic-response": "1.0.1"
       }
     },
     "deep-equal": {
@@ -2338,8 +2346,8 @@
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "requires": {
-        "foreach": "^2.0.5",
-        "object-keys": "^1.0.8"
+        "foreach": "2.0.5",
+        "object-keys": "1.0.12"
       }
     },
     "define-property": {
@@ -2347,8 +2355,8 @@
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "requires": {
-        "is-descriptor": "^1.0.2",
-        "isobject": "^3.0.1"
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -2356,7 +2364,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -2364,7 +2372,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -2372,9 +2380,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         }
       }
@@ -2390,7 +2398,7 @@
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "dev": true,
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "diff": {
@@ -2409,8 +2417,8 @@
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
       "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
       "requires": {
-        "arrify": "^1.0.1",
-        "path-type": "^3.0.0"
+        "arrify": "1.0.1",
+        "path-type": "3.0.0"
       }
     },
     "dot-prop": {
@@ -2419,7 +2427,7 @@
       "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
       "dev": true,
       "requires": {
-        "is-obj": "^1.0.0"
+        "is-obj": "1.0.1"
       }
     },
     "double-ended-queue": {
@@ -2438,10 +2446,10 @@
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
       "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
       "requires": {
-        "end-of-stream": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0",
-        "stream-shift": "^1.0.0"
+        "end-of-stream": "1.4.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "stream-shift": "1.0.0"
       }
     },
     "eastasianwidth": {
@@ -2455,7 +2463,7 @@
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "~0.1.0"
+        "jsbn": "0.1.1"
       }
     },
     "ecdsa-sig-formatter": {
@@ -2463,7 +2471,7 @@
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
       "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "empower": {
@@ -2471,8 +2479,8 @@
       "resolved": "https://registry.npmjs.org/empower/-/empower-1.3.0.tgz",
       "integrity": "sha512-tP2WqM7QzrPguCCQEQfFFDF+6Pw6YWLQal3+GHQaV+0uIr0S+jyREQPWljE02zFCYPFYLZ3LosiRV+OzTrxPpQ==",
       "requires": {
-        "core-js": "^2.0.0",
-        "empower-core": "^1.2.0"
+        "core-js": "2.5.7",
+        "empower-core": "1.2.0"
       }
     },
     "empower-core": {
@@ -2481,7 +2489,7 @@
       "integrity": "sha512-g6+K6Geyc1o6FdXs9HwrXleCFan7d66G5xSCfSF7x1mJDCes6t0om9lFQG3zOrzh3Bkb/45N0cZ5Gqsf7YrzGQ==",
       "requires": {
         "call-signature": "0.0.2",
-        "core-js": "^2.0.0"
+        "core-js": "2.5.7"
       }
     },
     "end-of-stream": {
@@ -2489,7 +2497,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
-        "once": "^1.4.0"
+        "once": "1.4.0"
       }
     },
     "ent": {
@@ -2509,7 +2517,7 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       }
     },
     "es6-error": {
@@ -2530,10 +2538,10 @@
       "integrity": "sha1-oXt+zFnTDheeK+9z+0E3cEyzMbU=",
       "dev": true,
       "requires": {
-        "is-url": "^1.2.1",
-        "path-is-absolute": "^1.0.0",
-        "source-map": "^0.5.0",
-        "xtend": "^4.0.0"
+        "is-url": "1.2.4",
+        "path-is-absolute": "1.0.1",
+        "source-map": "0.5.7",
+        "xtend": "4.0.1"
       }
     },
     "esprima": {
@@ -2547,7 +2555,7 @@
       "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.8.1.tgz",
       "integrity": "sha512-ZDko6eY/o+D/gHCWyHTU85mKDgYcS4FJj7S+YD6WIInm7GQ6AnOjmcL4+buFV/JOztVLELi/7MmuGU5NHta0Mg==",
       "requires": {
-        "core-js": "^2.0.0"
+        "core-js": "2.5.7"
       }
     },
     "estraverse": {
@@ -2566,13 +2574,13 @@
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
       }
     },
     "expand-brackets": {
@@ -2580,13 +2588,13 @@
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "requires": {
-        "debug": "^2.3.3",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "posix-character-classes": "^0.1.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "posix-character-classes": "0.1.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "debug": {
@@ -2602,7 +2610,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "extend-shallow": {
@@ -2610,7 +2618,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -2621,7 +2629,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "^2.1.0"
+        "fill-range": "2.2.4"
       },
       "dependencies": {
         "fill-range": {
@@ -2630,11 +2638,11 @@
           "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
           "dev": true,
           "requires": {
-            "is-number": "^2.1.0",
-            "isobject": "^2.0.0",
-            "randomatic": "^3.0.0",
-            "repeat-element": "^1.1.2",
-            "repeat-string": "^1.5.2"
+            "is-number": "2.1.0",
+            "isobject": "2.1.0",
+            "randomatic": "3.0.0",
+            "repeat-element": "1.1.2",
+            "repeat-string": "1.6.1"
           }
         },
         "is-number": {
@@ -2643,7 +2651,7 @@
           "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         },
         "isobject": {
@@ -2661,7 +2669,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -2676,8 +2684,8 @@
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "requires": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
+        "assign-symbols": "1.0.0",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -2685,7 +2693,7 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -2695,14 +2703,14 @@
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
       "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "requires": {
-        "array-unique": "^0.3.2",
-        "define-property": "^1.0.0",
-        "expand-brackets": "^2.1.4",
-        "extend-shallow": "^2.0.1",
-        "fragment-cache": "^0.2.1",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "array-unique": "0.3.2",
+        "define-property": "1.0.0",
+        "expand-brackets": "2.1.4",
+        "extend-shallow": "2.0.1",
+        "fragment-cache": "0.2.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "define-property": {
@@ -2710,7 +2718,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "extend-shallow": {
@@ -2718,7 +2726,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "is-accessor-descriptor": {
@@ -2726,7 +2734,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -2734,7 +2742,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -2742,9 +2750,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         }
       }
@@ -2770,12 +2778,12 @@
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.2.tgz",
       "integrity": "sha512-TR6zxCKftDQnUAPvkrCWdBgDq/gbqx8A3ApnBrR5rMvpp6+KMJI0Igw7fkWPgeVK0uhRXTXdvO3O+YP0CaUX2g==",
       "requires": {
-        "@mrmlnc/readdir-enhanced": "^2.2.1",
-        "@nodelib/fs.stat": "^1.0.1",
-        "glob-parent": "^3.1.0",
-        "is-glob": "^4.0.0",
-        "merge2": "^1.2.1",
-        "micromatch": "^3.1.10"
+        "@mrmlnc/readdir-enhanced": "2.2.1",
+        "@nodelib/fs.stat": "1.1.0",
+        "glob-parent": "3.1.0",
+        "is-glob": "4.0.0",
+        "merge2": "1.2.2",
+        "micromatch": "3.1.10"
       }
     },
     "fast-json-stable-stringify": {
@@ -2789,7 +2797,7 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.5"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "filename-regex": {
@@ -2804,8 +2812,8 @@
       "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
       "dev": true,
       "requires": {
-        "is-object": "~1.0.1",
-        "merge-descriptors": "~1.0.0"
+        "is-object": "1.0.1",
+        "merge-descriptors": "1.0.1"
       }
     },
     "fill-range": {
@@ -2813,10 +2821,10 @@
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1",
-        "to-regex-range": "^2.1.0"
+        "extend-shallow": "2.0.1",
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1",
+        "to-regex-range": "2.1.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -2824,7 +2832,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -2835,9 +2843,9 @@
       "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
       "dev": true,
       "requires": {
-        "commondir": "^1.0.1",
-        "make-dir": "^1.0.0",
-        "pkg-dir": "^2.0.0"
+        "commondir": "1.0.1",
+        "make-dir": "1.3.0",
+        "pkg-dir": "2.0.0"
       }
     },
     "find-up": {
@@ -2845,7 +2853,7 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "requires": {
-        "locate-path": "^3.0.0"
+        "locate-path": "3.0.0"
       }
     },
     "fn-name": {
@@ -2859,7 +2867,7 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.1.tgz",
       "integrity": "sha512-v9GI1hpaqq1ZZR6pBD1+kI7O24PhDvNGNodjS3MdcEqyrahCp8zbtpv+2B/krUnSmUH80lbAS7MrdeK5IylgKg==",
       "requires": {
-        "debug": "^3.1.0"
+        "debug": "3.1.0"
       }
     },
     "for-in": {
@@ -2873,7 +2881,7 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.1"
+        "for-in": "1.0.2"
       }
     },
     "foreach": {
@@ -2891,9 +2899,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
-        "asynckit": "^0.4.0",
+        "asynckit": "0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "^2.1.12"
+        "mime-types": "2.1.18"
       }
     },
     "formidable": {
@@ -2907,7 +2915,7 @@
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "requires": {
-        "map-cache": "^0.2.2"
+        "map-cache": "0.2.2"
       }
     },
     "from2": {
@@ -2916,8 +2924,8 @@
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
       }
     },
     "fs-extra": {
@@ -2926,9 +2934,9 @@
       "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "graceful-fs": "4.1.11",
+        "jsonfile": "4.0.0",
+        "universalify": "0.1.2"
       }
     },
     "fs.realpath": {
@@ -2943,8 +2951,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.10.0"
+        "nan": "2.10.0",
+        "node-pre-gyp": "0.10.0"
       },
       "dependencies": {
         "abbrev": {
@@ -2970,8 +2978,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
           }
         },
         "balanced-match": {
@@ -2984,7 +2992,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -3048,7 +3056,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.2.4"
           }
         },
         "fs.realpath": {
@@ -3063,14 +3071,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
           }
         },
         "glob": {
@@ -3079,12 +3087,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "has-unicode": {
@@ -3099,7 +3107,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "^2.1.0"
+            "safer-buffer": "2.1.2"
           }
         },
         "ignore-walk": {
@@ -3108,7 +3116,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimatch": "^3.0.4"
+            "minimatch": "3.0.4"
           }
         },
         "inflight": {
@@ -3117,8 +3125,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -3137,7 +3145,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "isarray": {
@@ -3151,7 +3159,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
@@ -3164,8 +3172,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.0"
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
           }
         },
         "minizlib": {
@@ -3174,7 +3182,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.2.4"
           }
         },
         "mkdirp": {
@@ -3197,9 +3205,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "^2.1.2",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.21",
+            "sax": "1.2.4"
           }
         },
         "node-pre-gyp": {
@@ -3208,16 +3216,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.2.0",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.1.10",
+            "npmlog": "4.1.2",
+            "rc": "1.2.7",
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "tar": "4.4.1"
           }
         },
         "nopt": {
@@ -3226,8 +3234,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
           }
         },
         "npm-bundled": {
@@ -3242,8 +3250,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
           }
         },
         "npmlog": {
@@ -3252,10 +3260,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "number-is-nan": {
@@ -3274,7 +3282,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
@@ -3295,8 +3303,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "path-is-absolute": {
@@ -3317,10 +3325,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "^0.5.1",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.5.1",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -3337,13 +3345,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "rimraf": {
@@ -3352,7 +3360,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         },
         "safe-buffer": {
@@ -3395,9 +3403,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "string_decoder": {
@@ -3406,7 +3414,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "strip-ansi": {
@@ -3414,7 +3422,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
@@ -3429,13 +3437,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "^1.0.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.2"
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.4",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
           }
         },
         "util-deprecate": {
@@ -3450,7 +3458,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "1.0.2"
           }
         },
         "wrappy": {
@@ -3476,8 +3484,8 @@
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.6.3.tgz",
       "integrity": "sha512-MSmczZctbz91AxCvqp9GHBoZOSbJKAICV7Ow/AIWSJZRrRchUd5NL1b2P4OfP+4m490BEUPhhARfpHdqCxuCvg==",
       "requires": {
-        "axios": "^0.18.0",
-        "extend": "^3.0.1",
+        "axios": "0.18.0",
+        "extend": "3.0.1",
         "retry-axios": "0.3.2"
       }
     },
@@ -3487,11 +3495,11 @@
       "integrity": "sha1-fymz7iPc7EFwNnwHEUGCScZgVF8=",
       "dev": true,
       "requires": {
-        "configstore": "^3.1.2",
-        "google-auto-auth": "^0.10.0",
-        "pumpify": "^1.4.0",
-        "request": "^2.85.0",
-        "stream-events": "^1.0.3"
+        "configstore": "3.1.2",
+        "google-auto-auth": "0.10.1",
+        "pumpify": "1.5.1",
+        "request": "2.87.0",
+        "stream-events": "1.0.4"
       }
     },
     "get-caller-file": {
@@ -3526,7 +3534,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "glob": {
@@ -3534,12 +3542,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "glob-base": {
@@ -3548,8 +3556,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
       },
       "dependencies": {
         "glob-parent": {
@@ -3558,7 +3566,7 @@
           "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
           "dev": true,
           "requires": {
-            "is-glob": "^2.0.0"
+            "is-glob": "2.0.1"
           }
         },
         "is-extglob": {
@@ -3573,7 +3581,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         }
       }
@@ -3583,8 +3591,8 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "requires": {
-        "is-glob": "^3.1.0",
-        "path-dirname": "^1.0.0"
+        "is-glob": "3.1.0",
+        "path-dirname": "1.0.2"
       },
       "dependencies": {
         "is-glob": {
@@ -3592,7 +3600,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "requires": {
-            "is-extglob": "^2.1.0"
+            "is-extglob": "2.1.1"
           }
         }
       }
@@ -3608,7 +3616,7 @@
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "dev": true,
       "requires": {
-        "ini": "^1.3.4"
+        "ini": "1.3.5"
       }
     },
     "globals": {
@@ -3622,13 +3630,13 @@
       "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
       "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
       "requires": {
-        "array-union": "^1.0.1",
-        "dir-glob": "^2.0.0",
-        "fast-glob": "^2.0.2",
-        "glob": "^7.1.2",
-        "ignore": "^3.3.5",
-        "pify": "^3.0.0",
-        "slash": "^1.0.0"
+        "array-union": "1.0.2",
+        "dir-glob": "2.0.0",
+        "fast-glob": "2.2.2",
+        "glob": "7.1.2",
+        "ignore": "3.3.10",
+        "pify": "3.0.0",
+        "slash": "1.0.0"
       }
     },
     "google-auth-library": {
@@ -3636,41 +3644,53 @@
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-1.6.1.tgz",
       "integrity": "sha512-jYiWC8NA9n9OtQM7ANn0Tk464do9yhKEtaJ72pKcaBiEwn4LwcGYIYOfwtfsSm3aur/ed3tlSxbmg24IAT6gAg==",
       "requires": {
-        "axios": "^0.18.0",
-        "gcp-metadata": "^0.6.3",
-        "gtoken": "^2.3.0",
-        "jws": "^3.1.5",
-        "lodash.isstring": "^4.0.1",
-        "lru-cache": "^4.1.3",
-        "retry-axios": "^0.3.2"
+        "axios": "0.18.0",
+        "gcp-metadata": "0.6.3",
+        "gtoken": "2.3.0",
+        "jws": "3.1.5",
+        "lodash.isstring": "4.0.1",
+        "lru-cache": "4.1.3",
+        "retry-axios": "0.3.2"
       }
     },
     "google-auto-auth": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.10.1.tgz",
       "integrity": "sha512-iIqSbY7Ypd32mnHGbYctp80vZzXoDlvI9gEfvtl3kmyy5HzOcrZCIGCBdSlIzRsg7nHpQiHE3Zl6Ycur6TSodQ==",
+      "dev": true,
       "requires": {
-        "async": "^2.3.0",
-        "gcp-metadata": "^0.6.1",
-        "google-auth-library": "^1.3.1",
-        "request": "^2.79.0"
+        "async": "2.6.1",
+        "gcp-metadata": "0.6.3",
+        "google-auth-library": "1.6.1",
+        "request": "2.87.0"
       }
     },
     "google-gax": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-0.16.1.tgz",
-      "integrity": "sha512-eP7UUkKvaHmmvCrr+rxzkIOeEKOnXmoib7/AkENDAuqlC9T2+lWlzwpthDRnitQcV8SblDMzsk73YPMPCDwPyQ==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-0.17.1.tgz",
+      "integrity": "sha512-fAKvFx++SRr6bGWamWuVOkJzJnQqMgpJkhaB2oEwfFJ91rbFgEmIPRmZZ/MeIVVFUOuHUVyZ8nwjm5peyTZJ6g==",
       "requires": {
-        "duplexify": "^3.5.4",
-        "extend": "^3.0.0",
-        "globby": "^8.0.0",
-        "google-auto-auth": "^0.10.0",
-        "google-proto-files": "^0.15.0",
-        "grpc": "^1.10.0",
-        "is-stream-ended": "^0.1.0",
-        "lodash": "^4.17.2",
-        "protobufjs": "^6.8.0",
-        "through2": "^2.0.3"
+        "duplexify": "3.6.0",
+        "extend": "3.0.1",
+        "globby": "8.0.1",
+        "google-auth-library": "1.6.1",
+        "google-proto-files": "0.16.1",
+        "grpc": "1.13.0",
+        "is-stream-ended": "0.1.4",
+        "lodash": "4.17.10",
+        "protobufjs": "6.8.8",
+        "retry-request": "4.0.0",
+        "through2": "2.0.3"
+      },
+      "dependencies": {
+        "retry-request": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-4.0.0.tgz",
+          "integrity": "sha512-S4HNLaWcMP6r8E4TMH52Y7/pM8uNayOcTDDQNBwsCccL1uI+Ol2TljxRDPzaNfbhOB30+XWP5NnZkB3LiJxi1w==",
+          "requires": {
+            "through2": "2.0.3"
+          }
+        }
       }
     },
     "google-p12-pem": {
@@ -3678,33 +3698,18 @@
       "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-1.0.2.tgz",
       "integrity": "sha512-+EuKr4CLlGsnXx4XIJIVkcKYrsa2xkAmCvxRhX2HsazJzUBAJ35wARGeApHUn4nNfPD03Vl057FskNr20VaCyg==",
       "requires": {
-        "node-forge": "^0.7.4",
-        "pify": "^3.0.0"
+        "node-forge": "0.7.5",
+        "pify": "3.0.0"
       }
     },
     "google-proto-files": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/google-proto-files/-/google-proto-files-0.15.1.tgz",
-      "integrity": "sha512-ebtmWgi/ooR5Nl63qRVZZ6VLM6JOb5zTNxTT/ZAU8yfMOdcauoOZNNMOVg0pCmTjqWXeuuVbgPP0CwO5UHHzBQ==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/google-proto-files/-/google-proto-files-0.16.1.tgz",
+      "integrity": "sha512-ykdhaYDiU/jlyrkzZDPemraKwVIgLT31XMHVNSJW//R9VED56hqSDRMx1Jlxbf0O4iDZnBWQ0JQLHbM2r5+wuA==",
       "requires": {
-        "globby": "^7.1.1",
-        "power-assert": "^1.4.4",
-        "protobufjs": "^6.8.0"
-      },
-      "dependencies": {
-        "globby": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
-          "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
-          "requires": {
-            "array-union": "^1.0.1",
-            "dir-glob": "^2.0.0",
-            "glob": "^7.1.2",
-            "ignore": "^3.3.5",
-            "pify": "^3.0.0",
-            "slash": "^1.0.0"
-          }
-        }
+        "globby": "8.0.1",
+        "power-assert": "1.6.0",
+        "protobufjs": "6.8.8"
       }
     },
     "got": {
@@ -3713,23 +3718,23 @@
       "integrity": "sha512-kBNy/S2CGwrYgDSec5KTWGKUvupwkkTVAjIsVFF2shXO13xpZdFP4d4kxa//CLX2tN/rV0aYwK8vY6UKWGn2vQ==",
       "dev": true,
       "requires": {
-        "@sindresorhus/is": "^0.7.0",
-        "cacheable-request": "^2.1.1",
-        "decompress-response": "^3.3.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^3.0.0",
-        "into-stream": "^3.1.0",
-        "is-retry-allowed": "^1.1.0",
-        "isurl": "^1.0.0-alpha5",
-        "lowercase-keys": "^1.0.0",
-        "mimic-response": "^1.0.0",
-        "p-cancelable": "^0.4.0",
-        "p-timeout": "^2.0.1",
-        "pify": "^3.0.0",
-        "safe-buffer": "^5.1.1",
-        "timed-out": "^4.0.1",
-        "url-parse-lax": "^3.0.0",
-        "url-to-options": "^1.0.1"
+        "@sindresorhus/is": "0.7.0",
+        "cacheable-request": "2.1.4",
+        "decompress-response": "3.3.0",
+        "duplexer3": "0.1.4",
+        "get-stream": "3.0.0",
+        "into-stream": "3.1.0",
+        "is-retry-allowed": "1.1.0",
+        "isurl": "1.0.0",
+        "lowercase-keys": "1.0.1",
+        "mimic-response": "1.0.1",
+        "p-cancelable": "0.4.1",
+        "p-timeout": "2.0.1",
+        "pify": "3.0.0",
+        "safe-buffer": "5.1.2",
+        "timed-out": "4.0.1",
+        "url-parse-lax": "3.0.0",
+        "url-to-options": "1.0.1"
       },
       "dependencies": {
         "prepend-http": {
@@ -3744,7 +3749,7 @@
           "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
           "dev": true,
           "requires": {
-            "prepend-http": "^2.0.0"
+            "prepend-http": "2.0.0"
           }
         }
       }
@@ -3760,10 +3765,10 @@
       "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.13.0.tgz",
       "integrity": "sha512-jGxWFYzttSz9pi8mu283jZvo2zIluWonQ918GMHKx8grT57GIVlvx7/82fo7AGS75lbkPoO1T6PZLvCRD9Pbtw==",
       "requires": {
-        "lodash": "^4.17.5",
-        "nan": "^2.0.0",
-        "node-pre-gyp": "^0.10.0",
-        "protobufjs": "^5.0.3"
+        "lodash": "4.17.10",
+        "nan": "2.10.0",
+        "node-pre-gyp": "0.10.2",
+        "protobufjs": "5.0.3"
       },
       "dependencies": {
         "abbrev": {
@@ -3782,8 +3787,8 @@
           "version": "1.1.5",
           "bundled": true,
           "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
           }
         },
         "balanced-match": {
@@ -3794,7 +3799,7 @@
           "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -3841,7 +3846,7 @@
           "version": "1.2.5",
           "bundled": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.3.3"
           }
         },
         "fs.realpath": {
@@ -3852,26 +3857,26 @@
           "version": "2.7.4",
           "bundled": true,
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.3"
           }
         },
         "glob": {
           "version": "7.1.2",
           "bundled": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "has-unicode": {
@@ -3882,22 +3887,22 @@
           "version": "0.4.23",
           "bundled": true,
           "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
+            "safer-buffer": "2.1.2"
           }
         },
         "ignore-walk": {
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "minimatch": "^3.0.4"
+            "minimatch": "3.0.4"
           }
         },
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -3912,7 +3917,7 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "isarray": {
@@ -3923,7 +3928,7 @@
           "version": "3.0.4",
           "bundled": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
@@ -3934,15 +3939,15 @@
           "version": "2.3.3",
           "bundled": true,
           "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.2"
           }
         },
         "minizlib": {
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.3.3"
           }
         },
         "mkdirp": {
@@ -3966,33 +3971,33 @@
           "version": "2.2.1",
           "bundled": true,
           "requires": {
-            "debug": "^2.1.2",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.23",
+            "sax": "1.2.4"
           }
         },
         "node-pre-gyp": {
           "version": "0.10.2",
           "bundled": true,
           "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.2.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.2.1",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.1.10",
+            "npmlog": "4.1.2",
+            "rc": "1.2.8",
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "tar": "4.4.4"
           }
         },
         "nopt": {
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
           }
         },
         "npm-bundled": {
@@ -4003,18 +4008,18 @@
           "version": "1.1.10",
           "bundled": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
           }
         },
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.5",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "number-is-nan": {
@@ -4029,7 +4034,7 @@
           "version": "1.4.0",
           "bundled": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
@@ -4044,8 +4049,8 @@
           "version": "0.1.5",
           "bundled": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "path-is-absolute": {
@@ -4061,40 +4066,40 @@
           "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.3.tgz",
           "integrity": "sha512-55Kcx1MhPZX0zTbVosMQEO5R6/rikNXd9b6RQK4KSPcrSIIwoXTtebIczUrXlwaSrbz4x8XUVThGPob1n8I4QA==",
           "requires": {
-            "ascli": "~1",
-            "bytebuffer": "~5",
-            "glob": "^7.0.5",
-            "yargs": "^3.10.0"
+            "ascli": "1.0.1",
+            "bytebuffer": "5.0.1",
+            "glob": "7.1.2",
+            "yargs": "3.32.0"
           }
         },
         "rc": {
           "version": "1.2.8",
           "bundled": true,
           "requires": {
-            "deep-extend": "^0.6.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.6.0",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           }
         },
         "readable-stream": {
           "version": "2.3.6",
           "bundled": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "rimraf": {
           "version": "2.6.2",
           "bundled": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         },
         "safe-buffer": {
@@ -4125,23 +4130,23 @@
           "version": "1.0.2",
           "bundled": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "string_decoder": {
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
@@ -4152,13 +4157,13 @@
           "version": "4.4.4",
           "bundled": true,
           "requires": {
-            "chownr": "^1.0.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.3",
-            "minizlib": "^1.1.0",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.3.3",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.2"
           }
         },
         "util-deprecate": {
@@ -4169,7 +4174,7 @@
           "version": "1.1.3",
           "bundled": true,
           "requires": {
-            "string-width": "^1.0.2 || 2"
+            "string-width": "1.0.2"
           }
         },
         "wrappy": {
@@ -4185,13 +4190,13 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
           "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
           "requires": {
-            "camelcase": "^2.0.1",
-            "cliui": "^3.0.3",
-            "decamelize": "^1.1.1",
-            "os-locale": "^1.4.0",
-            "string-width": "^1.0.1",
-            "window-size": "^0.1.4",
-            "y18n": "^3.2.0"
+            "camelcase": "2.1.1",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "os-locale": "1.4.0",
+            "string-width": "1.0.2",
+            "window-size": "0.1.4",
+            "y18n": "3.2.1"
           }
         }
       }
@@ -4201,11 +4206,11 @@
       "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-2.3.0.tgz",
       "integrity": "sha512-Jc9/8mV630cZE9FC5tIlJCZNdUjwunvlwOtCz6IDlaiB4Sz68ki29a1+q97sWTnTYroiuF9B135rod9zrQdHLw==",
       "requires": {
-        "axios": "^0.18.0",
-        "google-p12-pem": "^1.0.0",
-        "jws": "^3.1.4",
-        "mime": "^2.2.0",
-        "pify": "^3.0.0"
+        "axios": "0.18.0",
+        "google-p12-pem": "1.0.2",
+        "jws": "3.1.5",
+        "mime": "2.3.1",
+        "pify": "3.0.0"
       }
     },
     "handlebars": {
@@ -4214,10 +4219,10 @@
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
-        "async": "^1.4.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.4.4",
-        "uglify-js": "^2.6"
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4",
+        "uglify-js": "2.8.29"
       },
       "dependencies": {
         "async": {
@@ -4232,7 +4237,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         }
       }
@@ -4247,8 +4252,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "^5.1.0",
-        "har-schema": "^2.0.0"
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
       }
     },
     "has-ansi": {
@@ -4257,7 +4262,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "has-color": {
@@ -4284,7 +4289,7 @@
       "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
       "dev": true,
       "requires": {
-        "has-symbol-support-x": "^1.4.1"
+        "has-symbol-support-x": "1.4.2"
       }
     },
     "has-value": {
@@ -4292,9 +4297,9 @@
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "requires": {
-        "get-value": "^2.0.6",
-        "has-values": "^1.0.0",
-        "isobject": "^3.0.0"
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
       }
     },
     "has-values": {
@@ -4302,8 +4307,8 @@
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -4311,7 +4316,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -4328,7 +4333,7 @@
       "integrity": "sha1-7Mm5l7IYvluzEphii7gHhptz3NE=",
       "dev": true,
       "requires": {
-        "through2": "^2.0.0"
+        "through2": "2.0.3"
       }
     },
     "home-or-tmp": {
@@ -4337,8 +4342,8 @@
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "dev": true,
       "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.1"
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
       }
     },
     "hosted-git-info": {
@@ -4358,9 +4363,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.2"
       }
     },
     "hullabaloo-config-manager": {
@@ -4369,20 +4374,20 @@
       "integrity": "sha512-ztKnkZV0TmxnumCDHHgLGNiDnotu4EHCp9YMkznWuo4uTtCyJ+cu+RNcxUeXYKTllpvLFWnbfWry09yzszgg+A==",
       "dev": true,
       "requires": {
-        "dot-prop": "^4.1.0",
-        "es6-error": "^4.0.2",
-        "graceful-fs": "^4.1.11",
-        "indent-string": "^3.1.0",
-        "json5": "^0.5.1",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.clonedeepwith": "^4.5.0",
-        "lodash.isequal": "^4.5.0",
-        "lodash.merge": "^4.6.0",
-        "md5-hex": "^2.0.0",
-        "package-hash": "^2.0.0",
-        "pkg-dir": "^2.0.0",
-        "resolve-from": "^3.0.0",
-        "safe-buffer": "^5.0.1"
+        "dot-prop": "4.2.0",
+        "es6-error": "4.1.1",
+        "graceful-fs": "4.1.11",
+        "indent-string": "3.2.0",
+        "json5": "0.5.1",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.clonedeepwith": "4.5.0",
+        "lodash.isequal": "4.5.0",
+        "lodash.merge": "4.6.1",
+        "md5-hex": "2.0.0",
+        "package-hash": "2.0.0",
+        "pkg-dir": "2.0.0",
+        "resolve-from": "3.0.0",
+        "safe-buffer": "5.1.2"
       }
     },
     "ignore": {
@@ -4408,8 +4413,8 @@
       "integrity": "sha1-sReVcqrNwRxqkQCftDDbyrX2aKg=",
       "dev": true,
       "requires": {
-        "pkg-dir": "^2.0.0",
-        "resolve-cwd": "^2.0.0"
+        "pkg-dir": "2.0.0",
+        "resolve-cwd": "2.0.0"
       }
     },
     "imurmurhash": {
@@ -4434,8 +4439,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -4455,8 +4460,8 @@
       "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
       "dev": true,
       "requires": {
-        "from2": "^2.1.1",
-        "p-is-promise": "^1.1.0"
+        "from2": "2.3.0",
+        "p-is-promise": "1.1.0"
       }
     },
     "invariant": {
@@ -4465,7 +4470,7 @@
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.4.0"
       }
     },
     "invert-kv": {
@@ -4489,7 +4494,7 @@
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -4497,7 +4502,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -4514,7 +4519,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "^1.0.0"
+        "binary-extensions": "1.11.0"
       }
     },
     "is-buffer": {
@@ -4528,7 +4533,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "^1.0.0"
+        "builtin-modules": "1.1.1"
       }
     },
     "is-ci": {
@@ -4537,7 +4542,7 @@
       "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
       "dev": true,
       "requires": {
-        "ci-info": "^1.0.0"
+        "ci-info": "1.1.3"
       }
     },
     "is-data-descriptor": {
@@ -4545,7 +4550,7 @@
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -4553,7 +4558,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -4563,9 +4568,9 @@
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "requires": {
-        "is-accessor-descriptor": "^0.1.6",
-        "is-data-descriptor": "^0.1.4",
-        "kind-of": "^5.0.0"
+        "is-accessor-descriptor": "0.1.6",
+        "is-data-descriptor": "0.1.4",
+        "kind-of": "5.1.0"
       },
       "dependencies": {
         "kind-of": {
@@ -4587,7 +4592,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "^2.0.0"
+        "is-primitive": "2.0.0"
       }
     },
     "is-error": {
@@ -4612,7 +4617,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-fullwidth-code-point": {
@@ -4620,7 +4625,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-generator-fn": {
@@ -4634,7 +4639,7 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
       "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
       "requires": {
-        "is-extglob": "^2.1.1"
+        "is-extglob": "2.1.1"
       }
     },
     "is-installed-globally": {
@@ -4643,8 +4648,8 @@
       "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
       "dev": true,
       "requires": {
-        "global-dirs": "^0.1.0",
-        "is-path-inside": "^1.0.0"
+        "global-dirs": "0.1.1",
+        "is-path-inside": "1.0.1"
       }
     },
     "is-npm": {
@@ -4658,7 +4663,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -4666,7 +4671,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -4689,7 +4694,7 @@
       "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
       "dev": true,
       "requires": {
-        "symbol-observable": "^1.1.0"
+        "symbol-observable": "1.2.0"
       }
     },
     "is-path-inside": {
@@ -4698,7 +4703,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "^1.0.1"
+        "path-is-inside": "1.0.2"
       }
     },
     "is-plain-obj": {
@@ -4712,7 +4717,7 @@
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       }
     },
     "is-posix-bracket": {
@@ -4803,8 +4808,8 @@
       "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
       "dev": true,
       "requires": {
-        "has-to-string-tag-x": "^1.2.0",
-        "is-object": "^1.0.1"
+        "has-to-string-tag-x": "1.4.1",
+        "is-object": "1.0.1"
       }
     },
     "js-string-escape": {
@@ -4825,8 +4830,8 @@
       "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "1.0.10",
+        "esprima": "4.0.1"
       }
     },
     "jsbn": {
@@ -4868,7 +4873,7 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "requires": {
-        "jsonify": "~0.0.0"
+        "jsonify": "0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -4888,7 +4893,7 @@
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.6"
+        "graceful-fs": "4.1.11"
       }
     },
     "jsonify": {
@@ -4920,7 +4925,7 @@
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.10",
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "jws": {
@@ -4928,8 +4933,8 @@
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
       "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
       "requires": {
-        "jwa": "^1.1.5",
-        "safe-buffer": "^5.0.1"
+        "jwa": "1.1.6",
+        "safe-buffer": "5.1.2"
       }
     },
     "keyv": {
@@ -4952,7 +4957,7 @@
       "integrity": "sha1-0bZNafhv8kry0EiDos7uFFIKVgA=",
       "dev": true,
       "requires": {
-        "through2": "^2.0.0"
+        "through2": "2.0.3"
       }
     },
     "latest-version": {
@@ -4961,7 +4966,7 @@
       "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
       "dev": true,
       "requires": {
-        "package-json": "^4.0.0"
+        "package-json": "4.0.1"
       }
     },
     "lazy-cache": {
@@ -4976,7 +4981,7 @@
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "requires": {
-        "invert-kv": "^1.0.0"
+        "invert-kv": "1.0.0"
       }
     },
     "load-json-file": {
@@ -4985,10 +4990,10 @@
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "strip-bom": "^3.0.0"
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "strip-bom": "3.0.0"
       },
       "dependencies": {
         "pify": {
@@ -5004,8 +5009,8 @@
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
       "requires": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "3.0.0",
+        "path-exists": "3.0.0"
       }
     },
     "lodash": {
@@ -5100,7 +5105,7 @@
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
+        "js-tokens": "3.0.2"
       }
     },
     "loud-rejection": {
@@ -5109,8 +5114,8 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "^0.4.1",
-        "signal-exit": "^3.0.0"
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
       }
     },
     "lowercase-keys": {
@@ -5124,8 +5129,8 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
       "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
       }
     },
     "make-dir": {
@@ -5134,7 +5139,7 @@
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "dev": true,
       "requires": {
-        "pify": "^3.0.0"
+        "pify": "3.0.0"
       }
     },
     "map-cache": {
@@ -5153,7 +5158,7 @@
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "requires": {
-        "object-visit": "^1.0.0"
+        "object-visit": "1.0.1"
       }
     },
     "matcher": {
@@ -5162,7 +5167,7 @@
       "integrity": "sha512-+BmqxWIubKTRKNWx/ahnCkk3mG8m7OturVlqq6HiojGJTd5hVYbgZm6WzcYPCoB+KBT4Vd6R7WSRG2OADNaCjg==",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.4"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "math-random": {
@@ -5177,7 +5182,7 @@
       "integrity": "sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=",
       "dev": true,
       "requires": {
-        "md5-o-matic": "^0.1.1"
+        "md5-o-matic": "0.1.1"
       }
     },
     "md5-o-matic": {
@@ -5191,7 +5196,7 @@
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "meow": {
@@ -5200,16 +5205,16 @@
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "^2.0.0",
-        "decamelize": "^1.1.2",
-        "loud-rejection": "^1.0.0",
-        "map-obj": "^1.0.1",
-        "minimist": "^1.1.3",
-        "normalize-package-data": "^2.3.4",
-        "object-assign": "^4.0.1",
-        "read-pkg-up": "^1.0.1",
-        "redent": "^1.0.0",
-        "trim-newlines": "^1.0.0"
+        "camelcase-keys": "2.1.0",
+        "decamelize": "1.2.0",
+        "loud-rejection": "1.6.0",
+        "map-obj": "1.0.1",
+        "minimist": "1.2.0",
+        "normalize-package-data": "2.4.0",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "redent": "1.0.0",
+        "trim-newlines": "1.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -5218,8 +5223,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "load-json-file": {
@@ -5228,11 +5233,11 @@
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
           }
         },
         "minimist": {
@@ -5247,7 +5252,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "^2.0.0"
+            "pinkie-promise": "2.0.1"
           }
         },
         "path-type": {
@@ -5256,9 +5261,9 @@
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "pify": {
@@ -5279,7 +5284,7 @@
           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
           "dev": true,
           "requires": {
-            "pinkie": "^2.0.0"
+            "pinkie": "2.0.4"
           }
         },
         "read-pkg": {
@@ -5288,9 +5293,9 @@
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
           }
         },
         "read-pkg-up": {
@@ -5299,8 +5304,8 @@
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
           "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
           }
         },
         "strip-bom": {
@@ -5309,7 +5314,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         }
       }
@@ -5342,19 +5347,19 @@
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
       "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "braces": "^2.3.1",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "extglob": "^2.0.4",
-        "fragment-cache": "^0.2.1",
-        "kind-of": "^6.0.2",
-        "nanomatch": "^1.2.9",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.2"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "braces": "2.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "extglob": "2.0.4",
+        "fragment-cache": "0.2.1",
+        "kind-of": "6.0.2",
+        "nanomatch": "1.2.13",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       }
     },
     "mime": {
@@ -5372,7 +5377,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "requires": {
-        "mime-db": "~1.33.0"
+        "mime-db": "1.33.0"
       }
     },
     "mimic-fn": {
@@ -5391,7 +5396,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -5405,8 +5410,8 @@
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "requires": {
-        "for-in": "^1.0.2",
-        "is-extendable": "^1.0.1"
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -5414,7 +5419,7 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -5451,10 +5456,10 @@
       "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
       "dev": true,
       "requires": {
-        "array-differ": "^1.0.0",
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "minimatch": "^3.0.0"
+        "array-differ": "1.0.0",
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "minimatch": "3.0.4"
       }
     },
     "nan": {
@@ -5467,17 +5472,17 @@
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
       "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "fragment-cache": "^0.2.1",
-        "is-windows": "^1.0.2",
-        "kind-of": "^6.0.2",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "fragment-cache": "0.2.1",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.2",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       }
     },
     "natural": {
@@ -5485,11 +5490,11 @@
       "resolved": "https://registry.npmjs.org/natural/-/natural-0.6.1.tgz",
       "integrity": "sha1-Iwe/BPFyAShq6hRjCgj31/vC0GA=",
       "requires": {
-        "afinn-165": "^1.0.2",
-        "apparatus": "^0.0.10",
-        "json-stable-stringify": "^1.0.1",
-        "sylvester": "^0.0.12",
-        "underscore": "^1.3.1"
+        "afinn-165": "1.0.2",
+        "apparatus": "0.0.10",
+        "json-stable-stringify": "1.0.1",
+        "sylvester": "0.0.12",
+        "underscore": "1.9.1"
       }
     },
     "nise": {
@@ -5498,11 +5503,11 @@
       "integrity": "sha512-BxH/DxoQYYdhKgVAfqVy4pzXRZELHOIewzoesxpjYvpU+7YOalQhGNPf7wAx8pLrTNPrHRDlLOkAl8UI0ZpXjw==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^2.0.0",
-        "just-extend": "^1.1.27",
-        "lolex": "^2.3.2",
-        "path-to-regexp": "^1.7.0",
-        "text-encoding": "^0.6.4"
+        "@sinonjs/formatio": "2.0.0",
+        "just-extend": "1.1.27",
+        "lolex": "2.7.1",
+        "path-to-regexp": "1.7.0",
+        "text-encoding": "0.6.4"
       }
     },
     "node-forge": {
@@ -5516,10 +5521,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.7.1",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.5.0",
+        "validate-npm-package-license": "3.0.3"
       }
     },
     "normalize-path": {
@@ -5528,7 +5533,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "^1.0.1"
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "normalize-url": {
@@ -5537,9 +5542,9 @@
       "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
       "dev": true,
       "requires": {
-        "prepend-http": "^2.0.0",
-        "query-string": "^5.0.1",
-        "sort-keys": "^2.0.0"
+        "prepend-http": "2.0.0",
+        "query-string": "5.1.1",
+        "sort-keys": "2.0.0"
       },
       "dependencies": {
         "prepend-http": {
@@ -5555,7 +5560,7 @@
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "requires": {
-        "path-key": "^2.0.0"
+        "path-key": "2.0.1"
       }
     },
     "number-is-nan": {
@@ -5569,33 +5574,33 @@
       "integrity": "sha512-gBt7qwsR1vryYfglVjQRx1D+AtMZW5NbUKxb+lZe8SN8KsheGCPGWEsSC9AGQG+r2+te1+10uPHUCahuqm1nGQ==",
       "dev": true,
       "requires": {
-        "archy": "^1.0.0",
-        "arrify": "^1.0.1",
-        "caching-transform": "^1.0.0",
-        "convert-source-map": "^1.5.1",
-        "debug-log": "^1.0.1",
-        "default-require-extensions": "^1.0.0",
-        "find-cache-dir": "^0.1.1",
-        "find-up": "^2.1.0",
-        "foreground-child": "^1.5.3",
-        "glob": "^7.0.6",
-        "istanbul-lib-coverage": "^1.1.2",
-        "istanbul-lib-hook": "^1.1.0",
-        "istanbul-lib-instrument": "^1.10.0",
-        "istanbul-lib-report": "^1.1.3",
-        "istanbul-lib-source-maps": "^1.2.3",
-        "istanbul-reports": "^1.4.0",
-        "md5-hex": "^1.2.0",
-        "merge-source-map": "^1.1.0",
-        "micromatch": "^3.1.10",
-        "mkdirp": "^0.5.0",
-        "resolve-from": "^2.0.0",
-        "rimraf": "^2.6.2",
-        "signal-exit": "^3.0.1",
-        "spawn-wrap": "^1.4.2",
-        "test-exclude": "^4.2.0",
+        "archy": "1.0.0",
+        "arrify": "1.0.1",
+        "caching-transform": "1.0.1",
+        "convert-source-map": "1.5.1",
+        "debug-log": "1.0.1",
+        "default-require-extensions": "1.0.0",
+        "find-cache-dir": "0.1.1",
+        "find-up": "2.1.0",
+        "foreground-child": "1.5.6",
+        "glob": "7.1.2",
+        "istanbul-lib-coverage": "1.2.0",
+        "istanbul-lib-hook": "1.1.0",
+        "istanbul-lib-instrument": "1.10.1",
+        "istanbul-lib-report": "1.1.3",
+        "istanbul-lib-source-maps": "1.2.3",
+        "istanbul-reports": "1.4.0",
+        "md5-hex": "1.3.0",
+        "merge-source-map": "1.1.0",
+        "micromatch": "3.1.10",
+        "mkdirp": "0.5.1",
+        "resolve-from": "2.0.0",
+        "rimraf": "2.6.2",
+        "signal-exit": "3.0.2",
+        "spawn-wrap": "1.4.2",
+        "test-exclude": "4.2.1",
         "yargs": "11.1.0",
-        "yargs-parser": "^8.0.0"
+        "yargs-parser": "8.1.0"
       },
       "dependencies": {
         "align-text": {
@@ -5603,9 +5608,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2",
-            "longest": "^1.0.1",
-            "repeat-string": "^1.5.2"
+            "kind-of": "3.2.2",
+            "longest": "1.0.1",
+            "repeat-string": "1.6.1"
           }
         },
         "amdefine": {
@@ -5628,7 +5633,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "default-require-extensions": "^1.0.0"
+            "default-require-extensions": "1.0.0"
           }
         },
         "archy": {
@@ -5681,9 +5686,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "esutils": "^2.0.2",
-            "js-tokens": "^3.0.2"
+            "chalk": "1.1.3",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
           }
         },
         "babel-generator": {
@@ -5691,14 +5696,14 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-messages": "^6.23.0",
-            "babel-runtime": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "detect-indent": "^4.0.0",
-            "jsesc": "^1.3.0",
-            "lodash": "^4.17.4",
-            "source-map": "^0.5.7",
-            "trim-right": "^1.0.1"
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "detect-indent": "4.0.0",
+            "jsesc": "1.3.0",
+            "lodash": "4.17.10",
+            "source-map": "0.5.7",
+            "trim-right": "1.0.1"
           }
         },
         "babel-messages": {
@@ -5706,7 +5711,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.22.0"
+            "babel-runtime": "6.26.0"
           }
         },
         "babel-runtime": {
@@ -5714,8 +5719,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "core-js": "^2.4.0",
-            "regenerator-runtime": "^0.11.0"
+            "core-js": "2.5.6",
+            "regenerator-runtime": "0.11.1"
           }
         },
         "babel-template": {
@@ -5723,11 +5728,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.26.0",
-            "babel-traverse": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "babylon": "^6.18.0",
-            "lodash": "^4.17.4"
+            "babel-runtime": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "lodash": "4.17.10"
           }
         },
         "babel-traverse": {
@@ -5735,15 +5740,15 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-code-frame": "^6.26.0",
-            "babel-messages": "^6.23.0",
-            "babel-runtime": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "babylon": "^6.18.0",
-            "debug": "^2.6.8",
-            "globals": "^9.18.0",
-            "invariant": "^2.2.2",
-            "lodash": "^4.17.4"
+            "babel-code-frame": "6.26.0",
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "debug": "2.6.9",
+            "globals": "9.18.0",
+            "invariant": "2.2.4",
+            "lodash": "4.17.10"
           }
         },
         "babel-types": {
@@ -5751,10 +5756,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.26.0",
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.4",
-            "to-fast-properties": "^1.0.3"
+            "babel-runtime": "6.26.0",
+            "esutils": "2.0.2",
+            "lodash": "4.17.10",
+            "to-fast-properties": "1.0.3"
           }
         },
         "babylon": {
@@ -5772,13 +5777,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cache-base": "^1.0.1",
-            "class-utils": "^0.3.5",
-            "component-emitter": "^1.2.1",
-            "define-property": "^1.0.0",
-            "isobject": "^3.0.1",
-            "mixin-deep": "^1.2.0",
-            "pascalcase": "^0.1.1"
+            "cache-base": "1.0.1",
+            "class-utils": "0.3.6",
+            "component-emitter": "1.2.1",
+            "define-property": "1.0.0",
+            "isobject": "3.0.1",
+            "mixin-deep": "1.3.1",
+            "pascalcase": "0.1.1"
           },
           "dependencies": {
             "define-property": {
@@ -5786,7 +5791,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "is-accessor-descriptor": {
@@ -5794,7 +5799,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
               }
             },
             "is-data-descriptor": {
@@ -5802,7 +5807,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
               }
             },
             "is-descriptor": {
@@ -5810,9 +5815,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
               }
             },
             "kind-of": {
@@ -5827,7 +5832,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -5836,16 +5841,16 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -5853,7 +5858,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -5868,15 +5873,15 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "collection-visit": "^1.0.0",
-            "component-emitter": "^1.2.1",
-            "get-value": "^2.0.6",
-            "has-value": "^1.0.0",
-            "isobject": "^3.0.1",
-            "set-value": "^2.0.0",
-            "to-object-path": "^0.3.0",
-            "union-value": "^1.0.0",
-            "unset-value": "^1.0.0"
+            "collection-visit": "1.0.0",
+            "component-emitter": "1.2.1",
+            "get-value": "2.0.6",
+            "has-value": "1.0.0",
+            "isobject": "3.0.1",
+            "set-value": "2.0.0",
+            "to-object-path": "0.3.0",
+            "union-value": "1.0.0",
+            "unset-value": "1.0.0"
           }
         },
         "caching-transform": {
@@ -5884,9 +5889,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "md5-hex": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "write-file-atomic": "^1.1.4"
+            "md5-hex": "1.3.0",
+            "mkdirp": "0.5.1",
+            "write-file-atomic": "1.3.4"
           }
         },
         "camelcase": {
@@ -5901,8 +5906,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "align-text": "^0.1.3",
-            "lazy-cache": "^1.0.3"
+            "align-text": "0.1.4",
+            "lazy-cache": "1.0.4"
           }
         },
         "chalk": {
@@ -5910,11 +5915,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "class-utils": {
@@ -5922,10 +5927,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "arr-union": "^3.1.0",
-            "define-property": "^0.2.5",
-            "isobject": "^3.0.0",
-            "static-extend": "^0.1.1"
+            "arr-union": "3.1.0",
+            "define-property": "0.2.5",
+            "isobject": "3.0.1",
+            "static-extend": "0.1.2"
           },
           "dependencies": {
             "define-property": {
@@ -5933,7 +5938,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             }
           }
@@ -5944,8 +5949,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "center-align": "^0.1.1",
-            "right-align": "^0.1.1",
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
             "wordwrap": "0.0.2"
           },
           "dependencies": {
@@ -5967,8 +5972,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "map-visit": "^1.0.0",
-            "object-visit": "^1.0.0"
+            "map-visit": "1.0.0",
+            "object-visit": "1.0.1"
           }
         },
         "commondir": {
@@ -6006,8 +6011,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lru-cache": "^4.0.1",
-            "which": "^1.2.9"
+            "lru-cache": "4.1.3",
+            "which": "1.3.0"
           }
         },
         "debug": {
@@ -6038,7 +6043,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "strip-bom": "^2.0.0"
+            "strip-bom": "2.0.0"
           }
         },
         "define-property": {
@@ -6046,8 +6051,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.2",
-            "isobject": "^3.0.1"
+            "is-descriptor": "1.0.2",
+            "isobject": "3.0.1"
           },
           "dependencies": {
             "is-accessor-descriptor": {
@@ -6055,7 +6060,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
               }
             },
             "is-data-descriptor": {
@@ -6063,7 +6068,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
               }
             },
             "is-descriptor": {
@@ -6071,9 +6076,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
               }
             },
             "kind-of": {
@@ -6088,7 +6093,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "repeating": "^2.0.0"
+            "repeating": "2.0.1"
           }
         },
         "error-ex": {
@@ -6096,7 +6101,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-arrayish": "^0.2.1"
+            "is-arrayish": "0.2.1"
           }
         },
         "escape-string-regexp": {
@@ -6114,13 +6119,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
           },
           "dependencies": {
             "cross-spawn": {
@@ -6128,9 +6133,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "lru-cache": "^4.0.1",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
+                "lru-cache": "4.1.3",
+                "shebang-command": "1.2.0",
+                "which": "1.3.0"
               }
             }
           }
@@ -6140,13 +6145,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -6154,7 +6159,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -6162,7 +6167,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -6172,8 +6177,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
           },
           "dependencies": {
             "is-extendable": {
@@ -6181,7 +6186,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-plain-object": "^2.0.4"
+                "is-plain-object": "2.0.4"
               }
             }
           }
@@ -6191,14 +6196,14 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -6206,7 +6211,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -6214,7 +6219,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-accessor-descriptor": {
@@ -6222,7 +6227,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
               }
             },
             "is-data-descriptor": {
@@ -6230,7 +6235,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
               }
             },
             "is-descriptor": {
@@ -6238,9 +6243,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
               }
             },
             "kind-of": {
@@ -6255,10 +6260,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -6266,7 +6271,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -6276,9 +6281,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "commondir": "^1.0.1",
-            "mkdirp": "^0.5.1",
-            "pkg-dir": "^1.0.0"
+            "commondir": "1.0.1",
+            "mkdirp": "0.5.1",
+            "pkg-dir": "1.0.0"
           }
         },
         "find-up": {
@@ -6286,7 +6291,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "for-in": {
@@ -6299,8 +6304,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cross-spawn": "^4",
-            "signal-exit": "^3.0.0"
+            "cross-spawn": "4.0.2",
+            "signal-exit": "3.0.2"
           }
         },
         "fragment-cache": {
@@ -6308,7 +6313,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "map-cache": "^0.2.2"
+            "map-cache": "0.2.2"
           }
         },
         "fs.realpath": {
@@ -6336,12 +6341,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "globals": {
@@ -6359,10 +6364,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "async": "^1.4.0",
-            "optimist": "^0.6.1",
-            "source-map": "^0.4.4",
-            "uglify-js": "^2.6"
+            "async": "1.5.2",
+            "optimist": "0.6.1",
+            "source-map": "0.4.4",
+            "uglify-js": "2.8.29"
           },
           "dependencies": {
             "source-map": {
@@ -6370,7 +6375,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "amdefine": ">=0.0.4"
+                "amdefine": "1.0.1"
               }
             }
           }
@@ -6380,7 +6385,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "has-flag": {
@@ -6393,9 +6398,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "get-value": "^2.0.6",
-            "has-values": "^1.0.0",
-            "isobject": "^3.0.0"
+            "get-value": "2.0.6",
+            "has-values": "1.0.0",
+            "isobject": "3.0.1"
           }
         },
         "has-values": {
@@ -6403,8 +6408,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-number": "^3.0.0",
-            "kind-of": "^4.0.0"
+            "is-number": "3.0.0",
+            "kind-of": "4.0.0"
           },
           "dependencies": {
             "kind-of": {
@@ -6412,7 +6417,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -6432,8 +6437,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -6446,7 +6451,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "loose-envify": "^1.0.0"
+            "loose-envify": "1.3.1"
           }
         },
         "invert-kv": {
@@ -6459,7 +6464,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         },
         "is-arrayish": {
@@ -6477,7 +6482,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "builtin-modules": "^1.0.0"
+            "builtin-modules": "1.1.1"
           }
         },
         "is-data-descriptor": {
@@ -6485,7 +6490,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         },
         "is-descriptor": {
@@ -6493,9 +6498,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
           },
           "dependencies": {
             "kind-of": {
@@ -6515,7 +6520,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "is-fullwidth-code-point": {
@@ -6528,7 +6533,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         },
         "is-odd": {
@@ -6536,7 +6541,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-number": "^4.0.0"
+            "is-number": "4.0.0"
           },
           "dependencies": {
             "is-number": {
@@ -6551,7 +6556,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "isobject": "^3.0.1"
+            "isobject": "3.0.1"
           }
         },
         "is-stream": {
@@ -6594,7 +6599,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "append-transform": "^0.4.0"
+            "append-transform": "0.4.0"
           }
         },
         "istanbul-lib-instrument": {
@@ -6602,13 +6607,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-generator": "^6.18.0",
-            "babel-template": "^6.16.0",
-            "babel-traverse": "^6.18.0",
-            "babel-types": "^6.18.0",
-            "babylon": "^6.18.0",
-            "istanbul-lib-coverage": "^1.2.0",
-            "semver": "^5.3.0"
+            "babel-generator": "6.26.1",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "istanbul-lib-coverage": "1.2.0",
+            "semver": "5.5.0"
           }
         },
         "istanbul-lib-report": {
@@ -6616,10 +6621,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "istanbul-lib-coverage": "^1.1.2",
-            "mkdirp": "^0.5.1",
-            "path-parse": "^1.0.5",
-            "supports-color": "^3.1.2"
+            "istanbul-lib-coverage": "1.2.0",
+            "mkdirp": "0.5.1",
+            "path-parse": "1.0.5",
+            "supports-color": "3.2.3"
           },
           "dependencies": {
             "supports-color": {
@@ -6627,7 +6632,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "has-flag": "^1.0.0"
+                "has-flag": "1.0.0"
               }
             }
           }
@@ -6637,11 +6642,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "debug": "^3.1.0",
-            "istanbul-lib-coverage": "^1.1.2",
-            "mkdirp": "^0.5.1",
-            "rimraf": "^2.6.1",
-            "source-map": "^0.5.3"
+            "debug": "3.1.0",
+            "istanbul-lib-coverage": "1.2.0",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2",
+            "source-map": "0.5.7"
           },
           "dependencies": {
             "debug": {
@@ -6659,7 +6664,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "handlebars": "^4.0.3"
+            "handlebars": "4.0.11"
           }
         },
         "js-tokens": {
@@ -6677,7 +6682,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         },
         "lazy-cache": {
@@ -6691,7 +6696,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "invert-kv": "^1.0.0"
+            "invert-kv": "1.0.0"
           }
         },
         "load-json-file": {
@@ -6699,11 +6704,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
           }
         },
         "locate-path": {
@@ -6711,8 +6716,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
           },
           "dependencies": {
             "path-exists": {
@@ -6737,7 +6742,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "js-tokens": "^3.0.0"
+            "js-tokens": "3.0.2"
           }
         },
         "lru-cache": {
@@ -6745,8 +6750,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
           }
         },
         "map-cache": {
@@ -6759,7 +6764,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "object-visit": "^1.0.0"
+            "object-visit": "1.0.1"
           }
         },
         "md5-hex": {
@@ -6767,7 +6772,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "md5-o-matic": "^0.1.1"
+            "md5-o-matic": "0.1.1"
           }
         },
         "md5-o-matic": {
@@ -6780,7 +6785,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "mimic-fn": "^1.0.0"
+            "mimic-fn": "1.2.0"
           }
         },
         "merge-source-map": {
@@ -6788,7 +6793,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "source-map": "^0.6.1"
+            "source-map": "0.6.1"
           },
           "dependencies": {
             "source-map": {
@@ -6803,19 +6808,19 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -6835,7 +6840,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
@@ -6848,8 +6853,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "for-in": "^1.0.2",
-            "is-extendable": "^1.0.1"
+            "for-in": "1.0.2",
+            "is-extendable": "1.0.1"
           },
           "dependencies": {
             "is-extendable": {
@@ -6857,7 +6862,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-plain-object": "^2.0.4"
+                "is-plain-object": "2.0.4"
               }
             }
           }
@@ -6880,18 +6885,18 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "fragment-cache": "^0.2.1",
-            "is-odd": "^2.0.0",
-            "is-windows": "^1.0.2",
-            "kind-of": "^6.0.2",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "fragment-cache": "0.2.1",
+            "is-odd": "2.0.0",
+            "is-windows": "1.0.2",
+            "kind-of": "6.0.2",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -6906,10 +6911,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "^2.1.4",
-            "is-builtin-module": "^1.0.0",
-            "semver": "2 || 3 || 4 || 5",
-            "validate-npm-package-license": "^3.0.1"
+            "hosted-git-info": "2.6.0",
+            "is-builtin-module": "1.0.0",
+            "semver": "5.5.0",
+            "validate-npm-package-license": "3.0.3"
           }
         },
         "npm-run-path": {
@@ -6917,7 +6922,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "path-key": "^2.0.0"
+            "path-key": "2.0.1"
           }
         },
         "number-is-nan": {
@@ -6935,9 +6940,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "copy-descriptor": "^0.1.0",
-            "define-property": "^0.2.5",
-            "kind-of": "^3.0.3"
+            "copy-descriptor": "0.1.1",
+            "define-property": "0.2.5",
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "define-property": {
@@ -6945,7 +6950,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             }
           }
@@ -6955,7 +6960,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "isobject": "^3.0.0"
+            "isobject": "3.0.1"
           }
         },
         "object.pick": {
@@ -6963,7 +6968,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "isobject": "^3.0.1"
+            "isobject": "3.0.1"
           }
         },
         "once": {
@@ -6971,7 +6976,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "optimist": {
@@ -6979,8 +6984,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "minimist": "~0.0.1",
-            "wordwrap": "~0.0.2"
+            "minimist": "0.0.8",
+            "wordwrap": "0.0.3"
           }
         },
         "os-homedir": {
@@ -6993,9 +6998,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
           }
         },
         "p-finally": {
@@ -7008,7 +7013,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "p-try": "^1.0.0"
+            "p-try": "1.0.0"
           }
         },
         "p-locate": {
@@ -7016,7 +7021,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "p-limit": "^1.1.0"
+            "p-limit": "1.2.0"
           }
         },
         "p-try": {
@@ -7029,7 +7034,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "error-ex": "^1.2.0"
+            "error-ex": "1.3.1"
           }
         },
         "pascalcase": {
@@ -7042,7 +7047,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "pinkie-promise": "^2.0.0"
+            "pinkie-promise": "2.0.1"
           }
         },
         "path-is-absolute": {
@@ -7065,9 +7070,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "pify": {
@@ -7085,7 +7090,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "pinkie": "^2.0.0"
+            "pinkie": "2.0.4"
           }
         },
         "pkg-dir": {
@@ -7093,7 +7098,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "find-up": "^1.0.0"
+            "find-up": "1.1.2"
           },
           "dependencies": {
             "find-up": {
@@ -7101,8 +7106,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "path-exists": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
+                "path-exists": "2.1.0",
+                "pinkie-promise": "2.0.1"
               }
             }
           }
@@ -7122,9 +7127,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
           }
         },
         "read-pkg-up": {
@@ -7132,8 +7137,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
           },
           "dependencies": {
             "find-up": {
@@ -7141,8 +7146,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "path-exists": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
+                "path-exists": "2.1.0",
+                "pinkie-promise": "2.0.1"
               }
             }
           }
@@ -7157,8 +7162,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "extend-shallow": "^3.0.2",
-            "safe-regex": "^1.1.0"
+            "extend-shallow": "3.0.2",
+            "safe-regex": "1.1.0"
           }
         },
         "repeat-element": {
@@ -7176,7 +7181,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-finite": "^1.0.0"
+            "is-finite": "1.0.2"
           }
         },
         "require-directory": {
@@ -7210,7 +7215,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "align-text": "^0.1.1"
+            "align-text": "0.1.4"
           }
         },
         "rimraf": {
@@ -7218,7 +7223,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         },
         "safe-regex": {
@@ -7226,7 +7231,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ret": "~0.1.10"
+            "ret": "0.1.15"
           }
         },
         "semver": {
@@ -7244,10 +7249,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.3",
-            "split-string": "^3.0.1"
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "split-string": "3.1.0"
           },
           "dependencies": {
             "extend-shallow": {
@@ -7255,7 +7260,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -7265,7 +7270,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "shebang-regex": "^1.0.0"
+            "shebang-regex": "1.0.0"
           }
         },
         "shebang-regex": {
@@ -7288,14 +7293,14 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "base": "^0.11.1",
-            "debug": "^2.2.0",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "map-cache": "^0.2.2",
-            "source-map": "^0.5.6",
-            "source-map-resolve": "^0.5.0",
-            "use": "^3.1.0"
+            "base": "0.11.2",
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "map-cache": "0.2.2",
+            "source-map": "0.5.7",
+            "source-map-resolve": "0.5.1",
+            "use": "3.1.0"
           },
           "dependencies": {
             "define-property": {
@@ -7303,7 +7308,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -7311,7 +7316,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -7321,9 +7326,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "define-property": "^1.0.0",
-            "isobject": "^3.0.0",
-            "snapdragon-util": "^3.0.1"
+            "define-property": "1.0.0",
+            "isobject": "3.0.1",
+            "snapdragon-util": "3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -7331,7 +7336,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "is-accessor-descriptor": {
@@ -7339,7 +7344,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
               }
             },
             "is-data-descriptor": {
@@ -7347,7 +7352,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
               }
             },
             "is-descriptor": {
@@ -7355,9 +7360,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
               }
             },
             "kind-of": {
@@ -7372,7 +7377,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "^3.2.0"
+            "kind-of": "3.2.2"
           }
         },
         "source-map": {
@@ -7385,11 +7390,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "atob": "^2.0.0",
-            "decode-uri-component": "^0.2.0",
-            "resolve-url": "^0.2.1",
-            "source-map-url": "^0.4.0",
-            "urix": "^0.1.0"
+            "atob": "2.1.1",
+            "decode-uri-component": "0.2.0",
+            "resolve-url": "0.2.1",
+            "source-map-url": "0.4.0",
+            "urix": "0.1.0"
           }
         },
         "source-map-url": {
@@ -7402,12 +7407,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "foreground-child": "^1.5.6",
-            "mkdirp": "^0.5.0",
-            "os-homedir": "^1.0.1",
-            "rimraf": "^2.6.2",
-            "signal-exit": "^3.0.2",
-            "which": "^1.3.0"
+            "foreground-child": "1.5.6",
+            "mkdirp": "0.5.1",
+            "os-homedir": "1.0.2",
+            "rimraf": "2.6.2",
+            "signal-exit": "3.0.2",
+            "which": "1.3.0"
           }
         },
         "spdx-correct": {
@@ -7415,8 +7420,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "spdx-expression-parse": "^3.0.0",
-            "spdx-license-ids": "^3.0.0"
+            "spdx-expression-parse": "3.0.0",
+            "spdx-license-ids": "3.0.0"
           }
         },
         "spdx-exceptions": {
@@ -7429,8 +7434,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "spdx-exceptions": "^2.1.0",
-            "spdx-license-ids": "^3.0.0"
+            "spdx-exceptions": "2.1.0",
+            "spdx-license-ids": "3.0.0"
           }
         },
         "spdx-license-ids": {
@@ -7443,7 +7448,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "extend-shallow": "^3.0.0"
+            "extend-shallow": "3.0.2"
           }
         },
         "static-extend": {
@@ -7451,8 +7456,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "define-property": "^0.2.5",
-            "object-copy": "^0.1.0"
+            "define-property": "0.2.5",
+            "object-copy": "0.1.0"
           },
           "dependencies": {
             "define-property": {
@@ -7460,7 +7465,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             }
           }
@@ -7470,8 +7475,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -7484,7 +7489,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi-regex": "^3.0.0"
+                "ansi-regex": "3.0.0"
               }
             }
           }
@@ -7494,7 +7499,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-bom": {
@@ -7502,7 +7507,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         },
         "strip-eof": {
@@ -7520,11 +7525,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "arrify": "^1.0.1",
-            "micromatch": "^3.1.8",
-            "object-assign": "^4.1.0",
-            "read-pkg-up": "^1.0.1",
-            "require-main-filename": "^1.0.1"
+            "arrify": "1.0.1",
+            "micromatch": "3.1.10",
+            "object-assign": "4.1.1",
+            "read-pkg-up": "1.0.1",
+            "require-main-filename": "1.0.1"
           }
         },
         "to-fast-properties": {
@@ -7537,7 +7542,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         },
         "to-regex": {
@@ -7545,10 +7550,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "regex-not": "^1.0.2",
-            "safe-regex": "^1.1.0"
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "regex-not": "1.0.2",
+            "safe-regex": "1.1.0"
           }
         },
         "to-regex-range": {
@@ -7556,8 +7561,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1"
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1"
           }
         },
         "trim-right": {
@@ -7571,9 +7576,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "source-map": "~0.5.1",
-            "uglify-to-browserify": "~1.0.0",
-            "yargs": "~3.10.0"
+            "source-map": "0.5.7",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
           },
           "dependencies": {
             "yargs": {
@@ -7582,9 +7587,9 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "camelcase": "^1.0.2",
-                "cliui": "^2.1.0",
-                "decamelize": "^1.0.0",
+                "camelcase": "1.2.1",
+                "cliui": "2.1.0",
+                "decamelize": "1.2.0",
                 "window-size": "0.1.0"
               }
             }
@@ -7601,10 +7606,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "arr-union": "^3.1.0",
-            "get-value": "^2.0.6",
-            "is-extendable": "^0.1.1",
-            "set-value": "^0.4.3"
+            "arr-union": "3.1.0",
+            "get-value": "2.0.6",
+            "is-extendable": "0.1.1",
+            "set-value": "0.4.3"
           },
           "dependencies": {
             "extend-shallow": {
@@ -7612,7 +7617,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "set-value": {
@@ -7620,10 +7625,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "extend-shallow": "^2.0.1",
-                "is-extendable": "^0.1.1",
-                "is-plain-object": "^2.0.1",
-                "to-object-path": "^0.3.0"
+                "extend-shallow": "2.0.1",
+                "is-extendable": "0.1.1",
+                "is-plain-object": "2.0.4",
+                "to-object-path": "0.3.0"
               }
             }
           }
@@ -7633,8 +7638,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "has-value": "^0.3.1",
-            "isobject": "^3.0.0"
+            "has-value": "0.3.1",
+            "isobject": "3.0.1"
           },
           "dependencies": {
             "has-value": {
@@ -7642,9 +7647,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "get-value": "^2.0.3",
-                "has-values": "^0.1.4",
-                "isobject": "^2.0.0"
+                "get-value": "2.0.6",
+                "has-values": "0.1.4",
+                "isobject": "2.1.0"
               },
               "dependencies": {
                 "isobject": {
@@ -7674,7 +7679,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.2"
+            "kind-of": "6.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -7689,8 +7694,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "spdx-correct": "^3.0.0",
-            "spdx-expression-parse": "^3.0.0"
+            "spdx-correct": "3.0.0",
+            "spdx-expression-parse": "3.0.0"
           }
         },
         "which": {
@@ -7698,7 +7703,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "isexe": "^2.0.0"
+            "isexe": "2.0.0"
           }
         },
         "which-module": {
@@ -7722,8 +7727,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1"
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1"
           },
           "dependencies": {
             "is-fullwidth-code-point": {
@@ -7731,7 +7736,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "number-is-nan": "^1.0.0"
+                "number-is-nan": "1.0.1"
               }
             },
             "string-width": {
@@ -7739,9 +7744,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
               }
             }
           }
@@ -7756,9 +7761,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "slide": "^1.1.5"
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "slide": "1.1.6"
           }
         },
         "y18n": {
@@ -7776,18 +7781,18 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.1.1",
-            "find-up": "^2.1.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^9.0.2"
+            "cliui": "4.1.0",
+            "decamelize": "1.2.0",
+            "find-up": "2.1.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "9.0.2"
           },
           "dependencies": {
             "ansi-regex": {
@@ -7805,9 +7810,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "string-width": "^2.1.1",
-                "strip-ansi": "^4.0.0",
-                "wrap-ansi": "^2.0.0"
+                "string-width": "2.1.1",
+                "strip-ansi": "4.0.0",
+                "wrap-ansi": "2.1.0"
               }
             },
             "strip-ansi": {
@@ -7815,7 +7820,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi-regex": "^3.0.0"
+                "ansi-regex": "3.0.0"
               }
             },
             "yargs-parser": {
@@ -7823,7 +7828,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "camelcase": "^4.1.0"
+                "camelcase": "4.1.0"
               }
             }
           }
@@ -7833,7 +7838,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0"
+            "camelcase": "4.1.0"
           },
           "dependencies": {
             "camelcase": {
@@ -7861,9 +7866,9 @@
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "requires": {
-        "copy-descriptor": "^0.1.0",
-        "define-property": "^0.2.5",
-        "kind-of": "^3.0.3"
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "define-property": {
@@ -7871,7 +7876,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "kind-of": {
@@ -7879,7 +7884,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -7894,7 +7899,7 @@
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "requires": {
-        "isobject": "^3.0.0"
+        "isobject": "3.0.1"
       }
     },
     "object.omit": {
@@ -7903,8 +7908,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "^0.1.4",
-        "is-extendable": "^0.1.1"
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
       }
     },
     "object.pick": {
@@ -7912,7 +7917,7 @@
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       }
     },
     "observable-to-promise": {
@@ -7921,8 +7926,8 @@
       "integrity": "sha1-yCjw8NxH6fhq+KSXfF1VB2znqR8=",
       "dev": true,
       "requires": {
-        "is-observable": "^0.2.0",
-        "symbol-observable": "^1.0.4"
+        "is-observable": "0.2.0",
+        "symbol-observable": "1.2.0"
       },
       "dependencies": {
         "is-observable": {
@@ -7931,7 +7936,7 @@
           "integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
           "dev": true,
           "requires": {
-            "symbol-observable": "^0.2.2"
+            "symbol-observable": "0.2.4"
           },
           "dependencies": {
             "symbol-observable": {
@@ -7949,7 +7954,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "onetime": {
@@ -7958,7 +7963,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "optimist": {
@@ -7967,8 +7972,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.3"
       }
     },
     "option-chain": {
@@ -7993,7 +7998,7 @@
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "requires": {
-        "lcid": "^1.0.0"
+        "lcid": "1.0.0"
       }
     },
     "os-tmpdir": {
@@ -8024,7 +8029,7 @@
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
       "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
       "requires": {
-        "p-try": "^2.0.0"
+        "p-try": "2.0.0"
       }
     },
     "p-locate": {
@@ -8032,7 +8037,7 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "requires": {
-        "p-limit": "^2.0.0"
+        "p-limit": "2.0.0"
       }
     },
     "p-timeout": {
@@ -8041,7 +8046,7 @@
       "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
       "dev": true,
       "requires": {
-        "p-finally": "^1.0.0"
+        "p-finally": "1.0.0"
       }
     },
     "p-try": {
@@ -8055,10 +8060,10 @@
       "integrity": "sha1-eK4ybIngWk2BO2hgGXevBcANKg0=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "lodash.flattendeep": "^4.4.0",
-        "md5-hex": "^2.0.0",
-        "release-zalgo": "^1.0.0"
+        "graceful-fs": "4.1.11",
+        "lodash.flattendeep": "4.4.0",
+        "md5-hex": "2.0.0",
+        "release-zalgo": "1.0.0"
       }
     },
     "package-json": {
@@ -8067,10 +8072,10 @@
       "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "dev": true,
       "requires": {
-        "got": "^6.7.1",
-        "registry-auth-token": "^3.0.1",
-        "registry-url": "^3.0.3",
-        "semver": "^5.1.0"
+        "got": "6.7.1",
+        "registry-auth-token": "3.3.2",
+        "registry-url": "3.1.0",
+        "semver": "5.5.0"
       },
       "dependencies": {
         "got": {
@@ -8079,17 +8084,17 @@
           "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
           "dev": true,
           "requires": {
-            "create-error-class": "^3.0.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^3.0.0",
-            "is-redirect": "^1.0.0",
-            "is-retry-allowed": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "lowercase-keys": "^1.0.0",
-            "safe-buffer": "^5.0.1",
-            "timed-out": "^4.0.0",
-            "unzip-response": "^2.0.1",
-            "url-parse-lax": "^1.0.0"
+            "create-error-class": "3.0.2",
+            "duplexer3": "0.1.4",
+            "get-stream": "3.0.0",
+            "is-redirect": "1.0.0",
+            "is-retry-allowed": "1.1.0",
+            "is-stream": "1.1.0",
+            "lowercase-keys": "1.0.1",
+            "safe-buffer": "5.1.2",
+            "timed-out": "4.0.1",
+            "unzip-response": "2.0.1",
+            "url-parse-lax": "1.0.0"
           }
         }
       }
@@ -8100,10 +8105,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
       },
       "dependencies": {
         "is-extglob": {
@@ -8118,7 +8123,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         }
       }
@@ -8129,7 +8134,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "^1.2.0"
+        "error-ex": "1.3.2"
       }
     },
     "parse-ms": {
@@ -8191,7 +8196,7 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
       "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
       "requires": {
-        "pify": "^3.0.0"
+        "pify": "3.0.0"
       }
     },
     "performance-now": {
@@ -8216,7 +8221,7 @@
       "integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
       "dev": true,
       "requires": {
-        "pinkie": "^1.0.0"
+        "pinkie": "1.0.0"
       }
     },
     "pkg-conf": {
@@ -8225,8 +8230,8 @@
       "integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
       "dev": true,
       "requires": {
-        "find-up": "^2.0.0",
-        "load-json-file": "^4.0.0"
+        "find-up": "2.1.0",
+        "load-json-file": "4.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -8235,7 +8240,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "load-json-file": {
@@ -8244,10 +8249,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "4.0.0",
+            "pify": "3.0.0",
+            "strip-bom": "3.0.0"
           }
         },
         "locate-path": {
@@ -8256,8 +8261,8 @@
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
           }
         },
         "p-limit": {
@@ -8266,7 +8271,7 @@
           "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "dev": true,
           "requires": {
-            "p-try": "^1.0.0"
+            "p-try": "1.0.0"
           }
         },
         "p-locate": {
@@ -8275,7 +8280,7 @@
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
-            "p-limit": "^1.1.0"
+            "p-limit": "1.3.0"
           }
         },
         "p-try": {
@@ -8290,8 +8295,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
+            "error-ex": "1.3.2",
+            "json-parse-better-errors": "1.0.2"
           }
         }
       }
@@ -8302,7 +8307,7 @@
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "dev": true,
       "requires": {
-        "find-up": "^2.1.0"
+        "find-up": "2.1.0"
       },
       "dependencies": {
         "find-up": {
@@ -8311,7 +8316,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "locate-path": {
@@ -8320,8 +8325,8 @@
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
           }
         },
         "p-limit": {
@@ -8330,7 +8335,7 @@
           "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "dev": true,
           "requires": {
-            "p-try": "^1.0.0"
+            "p-try": "1.0.0"
           }
         },
         "p-locate": {
@@ -8339,7 +8344,7 @@
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
-            "p-limit": "^1.1.0"
+            "p-limit": "1.3.0"
           }
         },
         "p-try": {
@@ -8356,7 +8361,7 @@
       "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
       "dev": true,
       "requires": {
-        "irregular-plurals": "^1.0.0"
+        "irregular-plurals": "1.4.0"
       }
     },
     "posix-character-classes": {
@@ -8369,11 +8374,11 @@
       "resolved": "https://registry.npmjs.org/power-assert/-/power-assert-1.6.0.tgz",
       "integrity": "sha512-nDb6a+p2C7Wj8Y2zmFtLpuv+xobXz4+bzT5s7dr0nn71tLozn7nRMQqzwbefzwZN5qOm0N7Cxhw4kXP75xboKA==",
       "requires": {
-        "define-properties": "^1.1.2",
-        "empower": "^1.3.0",
-        "power-assert-formatter": "^1.4.1",
-        "universal-deep-strict-equal": "^1.2.1",
-        "xtend": "^4.0.0"
+        "define-properties": "1.1.2",
+        "empower": "1.3.0",
+        "power-assert-formatter": "1.4.1",
+        "universal-deep-strict-equal": "1.2.2",
+        "xtend": "4.0.1"
       }
     },
     "power-assert-context-formatter": {
@@ -8381,8 +8386,8 @@
       "resolved": "https://registry.npmjs.org/power-assert-context-formatter/-/power-assert-context-formatter-1.2.0.tgz",
       "integrity": "sha512-HLNEW8Bin+BFCpk/zbyKwkEu9W8/zThIStxGo7weYcFkKgMuGCHUJhvJeBGXDZf0Qm2xis4pbnnciGZiX0EpSg==",
       "requires": {
-        "core-js": "^2.0.0",
-        "power-assert-context-traversal": "^1.2.0"
+        "core-js": "2.5.7",
+        "power-assert-context-traversal": "1.2.0"
       }
     },
     "power-assert-context-reducer-ast": {
@@ -8390,11 +8395,11 @@
       "resolved": "https://registry.npmjs.org/power-assert-context-reducer-ast/-/power-assert-context-reducer-ast-1.2.0.tgz",
       "integrity": "sha512-EgOxmZ/Lb7tw4EwSKX7ZnfC0P/qRZFEG28dx/690qvhmOJ6hgThYFm5TUWANDLK5NiNKlPBi5WekVGd2+5wPrw==",
       "requires": {
-        "acorn": "^5.0.0",
-        "acorn-es7-plugin": "^1.0.12",
-        "core-js": "^2.0.0",
-        "espurify": "^1.6.0",
-        "estraverse": "^4.2.0"
+        "acorn": "5.7.1",
+        "acorn-es7-plugin": "1.1.7",
+        "core-js": "2.5.7",
+        "espurify": "1.8.1",
+        "estraverse": "4.2.0"
       }
     },
     "power-assert-context-traversal": {
@@ -8402,8 +8407,8 @@
       "resolved": "https://registry.npmjs.org/power-assert-context-traversal/-/power-assert-context-traversal-1.2.0.tgz",
       "integrity": "sha512-NFoHU6g2umNajiP2l4qb0BRWD773Aw9uWdWYH9EQsVwIZnog5bd2YYLFCVvaxWpwNzWeEfZIon2xtyc63026pQ==",
       "requires": {
-        "core-js": "^2.0.0",
-        "estraverse": "^4.1.0"
+        "core-js": "2.5.7",
+        "estraverse": "4.2.0"
       }
     },
     "power-assert-formatter": {
@@ -8411,13 +8416,13 @@
       "resolved": "https://registry.npmjs.org/power-assert-formatter/-/power-assert-formatter-1.4.1.tgz",
       "integrity": "sha1-XcEl7VCj37HdomwZNH879Y7CiEo=",
       "requires": {
-        "core-js": "^2.0.0",
-        "power-assert-context-formatter": "^1.0.7",
-        "power-assert-context-reducer-ast": "^1.0.7",
-        "power-assert-renderer-assertion": "^1.0.7",
-        "power-assert-renderer-comparison": "^1.0.7",
-        "power-assert-renderer-diagram": "^1.0.7",
-        "power-assert-renderer-file": "^1.0.7"
+        "core-js": "2.5.7",
+        "power-assert-context-formatter": "1.2.0",
+        "power-assert-context-reducer-ast": "1.2.0",
+        "power-assert-renderer-assertion": "1.2.0",
+        "power-assert-renderer-comparison": "1.2.0",
+        "power-assert-renderer-diagram": "1.2.0",
+        "power-assert-renderer-file": "1.2.0"
       }
     },
     "power-assert-renderer-assertion": {
@@ -8425,8 +8430,8 @@
       "resolved": "https://registry.npmjs.org/power-assert-renderer-assertion/-/power-assert-renderer-assertion-1.2.0.tgz",
       "integrity": "sha512-3F7Q1ZLmV2ZCQv7aV7NJLNK9G7QsostrhOU7U0RhEQS/0vhEqrRg2jEJl1jtUL4ZyL2dXUlaaqrmPv5r9kRvIg==",
       "requires": {
-        "power-assert-renderer-base": "^1.1.1",
-        "power-assert-util-string-width": "^1.2.0"
+        "power-assert-renderer-base": "1.1.1",
+        "power-assert-util-string-width": "1.2.0"
       }
     },
     "power-assert-renderer-base": {
@@ -8439,11 +8444,11 @@
       "resolved": "https://registry.npmjs.org/power-assert-renderer-comparison/-/power-assert-renderer-comparison-1.2.0.tgz",
       "integrity": "sha512-7c3RKPDBKK4E3JqdPtYRE9cM8AyX4LC4yfTvvTYyx8zSqmT5kJnXwzR0yWQLOavACllZfwrAGQzFiXPc5sWa+g==",
       "requires": {
-        "core-js": "^2.0.0",
-        "diff-match-patch": "^1.0.0",
-        "power-assert-renderer-base": "^1.1.1",
-        "stringifier": "^1.3.0",
-        "type-name": "^2.0.1"
+        "core-js": "2.5.7",
+        "diff-match-patch": "1.0.1",
+        "power-assert-renderer-base": "1.1.1",
+        "stringifier": "1.3.0",
+        "type-name": "2.0.2"
       }
     },
     "power-assert-renderer-diagram": {
@@ -8451,10 +8456,10 @@
       "resolved": "https://registry.npmjs.org/power-assert-renderer-diagram/-/power-assert-renderer-diagram-1.2.0.tgz",
       "integrity": "sha512-JZ6PC+DJPQqfU6dwSmpcoD7gNnb/5U77bU5KgNwPPa+i1Pxiz6UuDeM3EUBlhZ1HvH9tMjI60anqVyi5l2oNdg==",
       "requires": {
-        "core-js": "^2.0.0",
-        "power-assert-renderer-base": "^1.1.1",
-        "power-assert-util-string-width": "^1.2.0",
-        "stringifier": "^1.3.0"
+        "core-js": "2.5.7",
+        "power-assert-renderer-base": "1.1.1",
+        "power-assert-util-string-width": "1.2.0",
+        "stringifier": "1.3.0"
       }
     },
     "power-assert-renderer-file": {
@@ -8462,7 +8467,7 @@
       "resolved": "https://registry.npmjs.org/power-assert-renderer-file/-/power-assert-renderer-file-1.2.0.tgz",
       "integrity": "sha512-/oaVrRbeOtGoyyd7e4IdLP/jIIUFJdqJtsYzP9/88R39CMnfF/S/rUc8ZQalENfUfQ/wQHu+XZYRMaCEZmEesg==",
       "requires": {
-        "power-assert-renderer-base": "^1.1.1"
+        "power-assert-renderer-base": "1.1.1"
       }
     },
     "power-assert-util-string-width": {
@@ -8470,7 +8475,7 @@
       "resolved": "https://registry.npmjs.org/power-assert-util-string-width/-/power-assert-util-string-width-1.2.0.tgz",
       "integrity": "sha512-lX90G0igAW0iyORTILZ/QjZWsa1MZ6VVY3L0K86e2eKun3S4LKPH4xZIl8fdeMYLfOjkaszbNSzf1uugLeAm2A==",
       "requires": {
-        "eastasianwidth": "^0.2.0"
+        "eastasianwidth": "0.2.0"
       }
     },
     "prepend-http": {
@@ -8491,7 +8496,7 @@
       "integrity": "sha512-ZypexbfVUGTFxb0v+m1bUyy92DHe5SyYlnyY0msyms5zd3RwyvNgyxZZsXXgoyzlxjx5MiqtXUdhUfvQbe0A2Q==",
       "dev": true,
       "requires": {
-        "parse-ms": "^1.0.0"
+        "parse-ms": "1.0.1"
       },
       "dependencies": {
         "parse-ms": {
@@ -8514,30 +8519,23 @@
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "protobufjs": {
-      "version": "6.8.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.6.tgz",
-      "integrity": "sha512-eH2OTP9s55vojr3b7NBaF9i4WhWPkv/nq55nznWNp/FomKrLViprUcqnBjHph2tFQ+7KciGPTPsVWGz0SOhL0Q==",
+      "version": "6.8.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
+      "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
       "requires": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^3.0.32",
-        "@types/node": "^8.9.4",
-        "long": "^4.0.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "8.10.21",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.21.tgz",
-          "integrity": "sha512-87XkD9qDXm8fIax+5y7drx84cXsu34ZZqfB7Cial3Q/2lxSoJ/+DRaWckkCbxP41wFSIrrb939VhzaNxj4eY1w=="
-        }
+        "@protobufjs/aspromise": "1.1.2",
+        "@protobufjs/base64": "1.1.2",
+        "@protobufjs/codegen": "2.0.4",
+        "@protobufjs/eventemitter": "1.1.0",
+        "@protobufjs/fetch": "1.1.0",
+        "@protobufjs/float": "1.0.2",
+        "@protobufjs/inquire": "1.1.0",
+        "@protobufjs/path": "1.1.2",
+        "@protobufjs/pool": "1.1.0",
+        "@protobufjs/utf8": "1.1.0",
+        "@types/long": "4.0.0",
+        "@types/node": "10.5.2",
+        "long": "4.0.0"
       }
     },
     "proxyquire": {
@@ -8546,9 +8544,9 @@
       "integrity": "sha1-AtUUpb7ZhvBMuyCTrxZ0FTX3ntw=",
       "dev": true,
       "requires": {
-        "fill-keys": "^1.0.2",
-        "module-not-found-error": "^1.0.0",
-        "resolve": "~1.1.7"
+        "fill-keys": "1.0.2",
+        "module-not-found-error": "1.0.1",
+        "resolve": "1.1.7"
       }
     },
     "pseudomap": {
@@ -8562,8 +8560,8 @@
       "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
       "dev": true,
       "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
+        "end-of-stream": "1.4.1",
+        "once": "1.4.0"
       }
     },
     "pumpify": {
@@ -8572,9 +8570,9 @@
       "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "dev": true,
       "requires": {
-        "duplexify": "^3.6.0",
-        "inherits": "^2.0.3",
-        "pump": "^2.0.0"
+        "duplexify": "3.6.0",
+        "inherits": "2.0.3",
+        "pump": "2.0.1"
       }
     },
     "punycode": {
@@ -8593,9 +8591,9 @@
       "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
       "dev": true,
       "requires": {
-        "decode-uri-component": "^0.2.0",
-        "object-assign": "^4.1.0",
-        "strict-uri-encode": "^1.0.0"
+        "decode-uri-component": "0.2.0",
+        "object-assign": "4.1.1",
+        "strict-uri-encode": "1.1.0"
       }
     },
     "randomatic": {
@@ -8604,9 +8602,9 @@
       "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
       "dev": true,
       "requires": {
-        "is-number": "^4.0.0",
-        "kind-of": "^6.0.0",
-        "math-random": "^1.0.1"
+        "is-number": "4.0.0",
+        "kind-of": "6.0.2",
+        "math-random": "1.0.1"
       },
       "dependencies": {
         "is-number": {
@@ -8623,10 +8621,10 @@
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "dev": true,
       "requires": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
+        "deep-extend": "0.6.0",
+        "ini": "1.3.5",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
       },
       "dependencies": {
         "minimist": {
@@ -8643,9 +8641,9 @@
       "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
       "dev": true,
       "requires": {
-        "load-json-file": "^2.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^2.0.0"
+        "load-json-file": "2.0.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "2.0.0"
       },
       "dependencies": {
         "path-type": {
@@ -8654,7 +8652,7 @@
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
           "dev": true,
           "requires": {
-            "pify": "^2.0.0"
+            "pify": "2.3.0"
           }
         },
         "pify": {
@@ -8671,8 +8669,8 @@
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "dev": true,
       "requires": {
-        "find-up": "^2.0.0",
-        "read-pkg": "^2.0.0"
+        "find-up": "2.1.0",
+        "read-pkg": "2.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -8681,7 +8679,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "locate-path": {
@@ -8690,8 +8688,8 @@
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
           }
         },
         "p-limit": {
@@ -8700,7 +8698,7 @@
           "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "dev": true,
           "requires": {
-            "p-try": "^1.0.0"
+            "p-try": "1.0.0"
           }
         },
         "p-locate": {
@@ -8709,7 +8707,7 @@
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
-            "p-limit": "^1.1.0"
+            "p-limit": "1.3.0"
           }
         },
         "p-try": {
@@ -8725,13 +8723,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
       }
     },
     "readdirp": {
@@ -8740,10 +8738,10 @@
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "minimatch": "^3.0.2",
-        "readable-stream": "^2.0.2",
-        "set-immediate-shim": "^1.0.1"
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.3.6",
+        "set-immediate-shim": "1.0.1"
       }
     },
     "redent": {
@@ -8752,8 +8750,8 @@
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
-        "indent-string": "^2.1.0",
-        "strip-indent": "^1.0.1"
+        "indent-string": "2.1.0",
+        "strip-indent": "1.0.1"
       },
       "dependencies": {
         "indent-string": {
@@ -8762,7 +8760,7 @@
           "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
           "dev": true,
           "requires": {
-            "repeating": "^2.0.0"
+            "repeating": "2.0.1"
           }
         }
       }
@@ -8772,9 +8770,9 @@
       "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
       "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
       "requires": {
-        "double-ended-queue": "^2.1.0-0",
-        "redis-commands": "^1.2.0",
-        "redis-parser": "^2.6.0"
+        "double-ended-queue": "2.1.0-0",
+        "redis-commands": "1.3.5",
+        "redis-parser": "2.6.0"
       }
     },
     "redis-commands": {
@@ -8805,7 +8803,7 @@
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "^0.1.3"
+        "is-equal-shallow": "0.1.3"
       }
     },
     "regex-not": {
@@ -8813,8 +8811,8 @@
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "requires": {
-        "extend-shallow": "^3.0.2",
-        "safe-regex": "^1.1.0"
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "regexpu-core": {
@@ -8823,9 +8821,9 @@
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "dev": true,
       "requires": {
-        "regenerate": "^1.2.1",
-        "regjsgen": "^0.2.0",
-        "regjsparser": "^0.1.4"
+        "regenerate": "1.4.0",
+        "regjsgen": "0.2.0",
+        "regjsparser": "0.1.5"
       }
     },
     "registry-auth-token": {
@@ -8834,8 +8832,8 @@
       "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
       "dev": true,
       "requires": {
-        "rc": "^1.1.6",
-        "safe-buffer": "^5.0.1"
+        "rc": "1.2.8",
+        "safe-buffer": "5.1.2"
       }
     },
     "registry-url": {
@@ -8844,7 +8842,7 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "^1.0.1"
+        "rc": "1.2.8"
       }
     },
     "regjsgen": {
@@ -8859,7 +8857,7 @@
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
       "requires": {
-        "jsesc": "~0.5.0"
+        "jsesc": "0.5.0"
       }
     },
     "release-zalgo": {
@@ -8868,7 +8866,7 @@
       "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
       "dev": true,
       "requires": {
-        "es6-error": "^4.0.1"
+        "es6-error": "4.1.1"
       }
     },
     "remove-trailing-separator": {
@@ -8893,7 +8891,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "^1.0.0"
+        "is-finite": "1.0.2"
       }
     },
     "request": {
@@ -8901,26 +8899,26 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
       "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.6.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.5",
-        "extend": "~3.0.1",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.1",
-        "har-validator": "~5.0.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.17",
-        "oauth-sign": "~0.8.2",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.1",
-        "safe-buffer": "^5.1.1",
-        "tough-cookie": "~2.3.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.1.0"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.7.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.0.3",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.18",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.2",
+        "tough-cookie": "2.3.4",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.3.2"
       }
     },
     "require-directory": {
@@ -8951,7 +8949,7 @@
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "dev": true,
       "requires": {
-        "resolve-from": "^3.0.0"
+        "resolve-from": "3.0.0"
       }
     },
     "resolve-from": {
@@ -8971,7 +8969,7 @@
       "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
       "dev": true,
       "requires": {
-        "lowercase-keys": "^1.0.0"
+        "lowercase-keys": "1.0.1"
       }
     },
     "restore-cursor": {
@@ -8980,8 +8978,8 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "^2.0.0",
-        "signal-exit": "^3.0.2"
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
       }
     },
     "ret": {
@@ -8998,9 +8996,10 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-3.3.2.tgz",
       "integrity": "sha512-WIiGp37XXDC6e7ku3LFoi7LCL/Gs9luGeeqvbPRb+Zl6OQMw4RCRfSaW+aLfE6lhz1R941UavE6Svl3Dm5xGIQ==",
+      "dev": true,
       "requires": {
-        "request": "^2.81.0",
-        "through2": "^2.0.0"
+        "request": "2.87.0",
+        "through2": "2.0.3"
       }
     },
     "right-align": {
@@ -9010,7 +9009,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "^0.1.1"
+        "align-text": "0.1.4"
       }
     },
     "safe-buffer": {
@@ -9023,7 +9022,7 @@
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
-        "ret": "~0.1.10"
+        "ret": "0.1.15"
       }
     },
     "safer-buffer": {
@@ -9049,7 +9048,7 @@
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "dev": true,
       "requires": {
-        "semver": "^5.0.3"
+        "semver": "5.5.0"
       }
     },
     "serialize-error": {
@@ -9074,10 +9073,10 @@
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -9085,7 +9084,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -9095,7 +9094,7 @@
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "1.0.0"
       }
     },
     "shebang-regex": {
@@ -9114,13 +9113,13 @@
       "integrity": "sha512-rfszhNcfamK2+ofIPi9XqeH89pH7KGDcAtM+F9CsjHXOK3jzWG99vyhyD2V+r7s4IipmWcWUFYq4ftZ9/Eu2Wg==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^2.0.0",
-        "diff": "^3.5.0",
-        "lodash.get": "^4.4.2",
-        "lolex": "^2.4.2",
-        "nise": "^1.3.3",
-        "supports-color": "^5.4.0",
-        "type-detect": "^4.0.8"
+        "@sinonjs/formatio": "2.0.0",
+        "diff": "3.5.0",
+        "lodash.get": "4.4.2",
+        "lolex": "2.7.1",
+        "nise": "1.4.2",
+        "supports-color": "5.4.0",
+        "type-detect": "4.0.8"
       }
     },
     "slash": {
@@ -9134,7 +9133,7 @@
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0"
+        "is-fullwidth-code-point": "2.0.0"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -9162,14 +9161,14 @@
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "requires": {
-        "base": "^0.11.1",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "map-cache": "^0.2.2",
-        "source-map": "^0.5.6",
-        "source-map-resolve": "^0.5.0",
-        "use": "^3.1.0"
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.2",
+        "use": "3.1.1"
       },
       "dependencies": {
         "debug": {
@@ -9185,7 +9184,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "extend-shallow": {
@@ -9193,7 +9192,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -9203,9 +9202,9 @@
       "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "requires": {
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.0",
-        "snapdragon-util": "^3.0.1"
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -9213,7 +9212,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -9221,7 +9220,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -9229,7 +9228,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -9237,9 +9236,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         }
       }
@@ -9249,7 +9248,7 @@
       "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "requires": {
-        "kind-of": "^3.2.0"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -9257,7 +9256,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -9268,7 +9267,7 @@
       "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
       "dev": true,
       "requires": {
-        "is-plain-obj": "^1.0.0"
+        "is-plain-obj": "1.1.0"
       }
     },
     "source-map": {
@@ -9281,11 +9280,11 @@
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
       "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "requires": {
-        "atob": "^2.1.1",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
+        "atob": "2.1.1",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
       }
     },
     "source-map-support": {
@@ -9294,8 +9293,8 @@
       "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
       "dev": true,
       "requires": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
+        "buffer-from": "1.1.0",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -9317,8 +9316,8 @@
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -9333,8 +9332,8 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-exceptions": "2.1.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -9348,7 +9347,7 @@
       "resolved": "https://registry.npmjs.org/split-array-stream/-/split-array-stream-2.0.0.tgz",
       "integrity": "sha512-hmMswlVY91WvGMxs0k8MRgq8zb2mSen4FmDNc5AFiTWtrBpdZN6nwD6kROVe4vNL+ywrvbCKsWVCnEd4riELIg==",
       "requires": {
-        "is-stream-ended": "^0.1.4"
+        "is-stream-ended": "0.1.4"
       }
     },
     "split-string": {
@@ -9356,7 +9355,7 @@
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "requires": {
-        "extend-shallow": "^3.0.0"
+        "extend-shallow": "3.0.2"
       }
     },
     "sprintf-js": {
@@ -9370,15 +9369,15 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
       "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.2",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
+        "tweetnacl": "0.14.5"
       }
     },
     "stack-utils": {
@@ -9392,8 +9391,8 @@
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "requires": {
-        "define-property": "^0.2.5",
-        "object-copy": "^0.1.0"
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -9401,7 +9400,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -9411,7 +9410,7 @@
       "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.4.tgz",
       "integrity": "sha512-D243NJaYs/xBN2QnoiMDY7IesJFIK7gEhnvAYqJa5JvDdnh2dC4qDBwlCf0ohPpX2QRlA/4gnbnPd3rs3KxVcA==",
       "requires": {
-        "stubs": "^3.0.0"
+        "stubs": "3.0.0"
       }
     },
     "stream-shift": {
@@ -9442,9 +9441,9 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
       }
     },
     "string_decoder": {
@@ -9452,7 +9451,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.2"
       }
     },
     "stringifier": {
@@ -9460,9 +9459,9 @@
       "resolved": "https://registry.npmjs.org/stringifier/-/stringifier-1.3.0.tgz",
       "integrity": "sha1-3vGDQvaTPbDy2/yaoCF1tEjBeVk=",
       "requires": {
-        "core-js": "^2.0.0",
-        "traverse": "^0.6.6",
-        "type-name": "^2.0.1"
+        "core-js": "2.5.7",
+        "traverse": "0.6.6",
+        "type-name": "2.0.2"
       }
     },
     "strip-ansi": {
@@ -9470,7 +9469,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-bom": {
@@ -9485,7 +9484,7 @@
       "integrity": "sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=",
       "dev": true,
       "requires": {
-        "is-utf8": "^0.2.1"
+        "is-utf8": "0.2.1"
       }
     },
     "strip-eof": {
@@ -9499,7 +9498,7 @@
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "^4.0.1"
+        "get-stdin": "4.0.1"
       }
     },
     "strip-json-comments": {
@@ -9519,16 +9518,16 @@
       "integrity": "sha512-gVH4QfYHcY3P0f/BZzavLreHW3T1v7hG9B+hpMQotGQqurOvhv87GcMCd6LWySmBuf+BDR44TQd0aISjVHLeNQ==",
       "dev": true,
       "requires": {
-        "component-emitter": "^1.2.0",
-        "cookiejar": "^2.1.0",
-        "debug": "^3.1.0",
-        "extend": "^3.0.0",
-        "form-data": "^2.3.1",
-        "formidable": "^1.1.1",
-        "methods": "^1.1.1",
-        "mime": "^1.4.1",
-        "qs": "^6.5.1",
-        "readable-stream": "^2.0.5"
+        "component-emitter": "1.2.1",
+        "cookiejar": "2.1.2",
+        "debug": "3.1.0",
+        "extend": "3.0.1",
+        "form-data": "2.3.2",
+        "formidable": "1.2.1",
+        "methods": "1.1.2",
+        "mime": "1.6.0",
+        "qs": "6.5.2",
+        "readable-stream": "2.3.6"
       },
       "dependencies": {
         "mime": {
@@ -9545,11 +9544,11 @@
       "integrity": "sha512-HZJ3geIMPgVwKk2VsmO5YHqnnJYl6bV5A9JW2uzqV43WmpgliNEYbuvukfor7URpaqpxuw3CfZ3ONdVbZjCgIA==",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.1",
-        "indent-string": "^3.2.0",
-        "js-yaml": "^3.10.0",
-        "serialize-error": "^2.1.0",
-        "strip-ansi": "^4.0.0"
+        "arrify": "1.0.1",
+        "indent-string": "3.2.0",
+        "js-yaml": "3.12.0",
+        "serialize-error": "2.1.0",
+        "strip-ansi": "4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -9564,7 +9563,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -9575,7 +9574,7 @@
       "integrity": "sha512-O44AMnmJqx294uJQjfUmEyYOg7d9mylNFsMw/Wkz4evKd1njyPrtCN+U6ZIC7sKtfEVQhfTqFFijlXx8KP/Czw==",
       "dev": true,
       "requires": {
-        "methods": "~1.1.2",
+        "methods": "1.1.2",
         "superagent": "3.8.2"
       }
     },
@@ -9585,7 +9584,7 @@
       "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
       "dev": true,
       "requires": {
-        "has-flag": "^3.0.0"
+        "has-flag": "3.0.0"
       },
       "dependencies": {
         "has-flag": {
@@ -9613,7 +9612,7 @@
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
       "dev": true,
       "requires": {
-        "execa": "^0.7.0"
+        "execa": "0.7.0"
       }
     },
     "text-encoding": {
@@ -9633,8 +9632,8 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "requires": {
-        "readable-stream": "^2.1.5",
-        "xtend": "~4.0.1"
+        "readable-stream": "2.3.6",
+        "xtend": "4.0.1"
       }
     },
     "time-zone": {
@@ -9660,7 +9659,7 @@
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -9668,7 +9667,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -9678,10 +9677,10 @@
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "requires": {
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "regex-not": "^1.0.2",
-        "safe-regex": "^1.1.0"
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "regex-not": "1.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "to-regex-range": {
@@ -9689,8 +9688,8 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "requires": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
       }
     },
     "tough-cookie": {
@@ -9698,7 +9697,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "requires": {
-        "punycode": "^1.4.1"
+        "punycode": "1.4.1"
       }
     },
     "traverse": {
@@ -9729,7 +9728,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "tweetnacl": {
@@ -9762,9 +9761,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
-        "yargs": "~3.10.0"
+        "source-map": "0.5.7",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
       },
       "dependencies": {
         "camelcase": {
@@ -9781,8 +9780,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "center-align": "^0.1.1",
-            "right-align": "^0.1.1",
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
             "wordwrap": "0.0.2"
           }
         },
@@ -9807,9 +9806,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "camelcase": "^1.0.2",
-            "cliui": "^2.1.0",
-            "decamelize": "^1.0.0",
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
             "window-size": "0.1.0"
           }
         }
@@ -9838,10 +9837,10 @@
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "requires": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
       },
       "dependencies": {
         "extend-shallow": {
@@ -9849,7 +9848,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "set-value": {
@@ -9857,10 +9856,10 @@
           "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
           }
         }
       }
@@ -9871,7 +9870,7 @@
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "dev": true,
       "requires": {
-        "crypto-random-string": "^1.0.0"
+        "crypto-random-string": "1.0.0"
       }
     },
     "unique-temp-dir": {
@@ -9880,8 +9879,8 @@
       "integrity": "sha1-bc6VsmgcoAPuv7MEpBX5y6vMU4U=",
       "dev": true,
       "requires": {
-        "mkdirp": "^0.5.1",
-        "os-tmpdir": "^1.0.1",
+        "mkdirp": "0.5.1",
+        "os-tmpdir": "1.0.2",
         "uid2": "0.0.3"
       }
     },
@@ -9890,9 +9889,9 @@
       "resolved": "https://registry.npmjs.org/universal-deep-strict-equal/-/universal-deep-strict-equal-1.2.2.tgz",
       "integrity": "sha1-DaSsL3PP95JMgfpN4BjKViyisKc=",
       "requires": {
-        "array-filter": "^1.0.0",
+        "array-filter": "1.0.0",
         "indexof": "0.0.1",
-        "object-keys": "^1.0.0"
+        "object-keys": "1.0.12"
       }
     },
     "universalify": {
@@ -9906,8 +9905,8 @@
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "requires": {
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0"
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "has-value": {
@@ -9915,9 +9914,9 @@
           "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
           },
           "dependencies": {
             "isobject": {
@@ -9949,16 +9948,16 @@
       "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
       "dev": true,
       "requires": {
-        "boxen": "^1.2.1",
-        "chalk": "^2.0.1",
-        "configstore": "^3.0.0",
-        "import-lazy": "^2.1.0",
-        "is-ci": "^1.0.10",
-        "is-installed-globally": "^0.1.0",
-        "is-npm": "^1.0.0",
-        "latest-version": "^3.0.0",
-        "semver-diff": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
+        "boxen": "1.3.0",
+        "chalk": "2.4.1",
+        "configstore": "3.1.2",
+        "import-lazy": "2.1.0",
+        "is-ci": "1.1.0",
+        "is-installed-globally": "0.1.0",
+        "is-npm": "1.0.0",
+        "latest-version": "3.1.0",
+        "semver-diff": "2.1.0",
+        "xdg-basedir": "3.0.0"
       }
     },
     "urix": {
@@ -9972,7 +9971,7 @@
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "dev": true,
       "requires": {
-        "prepend-http": "^1.0.1"
+        "prepend-http": "1.0.4"
       }
     },
     "url-to-options": {
@@ -10002,8 +10001,8 @@
       "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
       "dev": true,
       "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
+        "spdx-correct": "3.0.0",
+        "spdx-expression-parse": "3.0.0"
       }
     },
     "verror": {
@@ -10011,9 +10010,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "^1.0.0",
+        "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "extsprintf": "1.3.0"
       }
     },
     "well-known-symbols": {
@@ -10027,7 +10026,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "which-module": {
@@ -10041,7 +10040,7 @@
       "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
       "dev": true,
       "requires": {
-        "string-width": "^2.1.1"
+        "string-width": "2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -10062,8 +10061,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -10072,7 +10071,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -10093,8 +10092,8 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
       }
     },
     "wrappy": {
@@ -10108,9 +10107,9 @@
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.2"
+        "graceful-fs": "4.1.11",
+        "imurmurhash": "0.1.4",
+        "signal-exit": "3.0.2"
       }
     },
     "write-json-file": {
@@ -10119,12 +10118,12 @@
       "integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
       "dev": true,
       "requires": {
-        "detect-indent": "^5.0.0",
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^1.0.0",
-        "pify": "^3.0.0",
-        "sort-keys": "^2.0.0",
-        "write-file-atomic": "^2.0.0"
+        "detect-indent": "5.0.0",
+        "graceful-fs": "4.1.11",
+        "make-dir": "1.3.0",
+        "pify": "3.0.0",
+        "sort-keys": "2.0.0",
+        "write-file-atomic": "2.3.0"
       },
       "dependencies": {
         "detect-indent": {
@@ -10141,8 +10140,8 @@
       "integrity": "sha512-tX2ifZ0YqEFOF1wjRW2Pk93NLsj02+n1UP5RvO6rCs0K6R2g1padvf006cY74PQJKMGS2r42NK7FD0dG6Y6paw==",
       "dev": true,
       "requires": {
-        "sort-keys": "^2.0.0",
-        "write-json-file": "^2.2.0"
+        "sort-keys": "2.0.0",
+        "write-json-file": "2.3.0"
       }
     },
     "xdg-basedir": {
@@ -10176,18 +10175,18 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.1.tgz",
       "integrity": "sha512-B0vRAp1hRX4jgIOWFtjfNjd9OA9RWYZ6tqGA9/I/IrTMsxmKvtWy+ersM+jzpQqbC3YfLzeABPdeTgcJ9eu1qQ==",
       "requires": {
-        "cliui": "^4.0.0",
-        "decamelize": "^2.0.0",
-        "find-up": "^3.0.0",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^2.0.0",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^2.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^3.2.1 || ^4.0.0",
-        "yargs-parser": "^10.1.0"
+        "cliui": "4.1.0",
+        "decamelize": "2.0.0",
+        "find-up": "3.0.0",
+        "get-caller-file": "1.0.3",
+        "os-locale": "2.1.0",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "2.1.1",
+        "which-module": "2.0.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "10.1.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -10200,9 +10199,9 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
           "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
           "requires": {
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "wrap-ansi": "2.1.0"
           }
         },
         "decamelize": {
@@ -10223,9 +10222,9 @@
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
           "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
           }
         },
         "string-width": {
@@ -10233,8 +10232,8 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -10242,7 +10241,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -10252,7 +10251,7 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
       "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
       "requires": {
-        "camelcase": "^4.1.0"
+        "camelcase": "4.1.0"
       },
       "dependencies": {
         "camelcase": {

--- a/samples/package.json
+++ b/samples/package.json
@@ -12,7 +12,7 @@
     "test": "ava -T 1m --verbose system-test/*.test.js"
   },
   "dependencies": {
-    "@google-cloud/vision": "^0.20.0",
+    "@google-cloud/vision": "^0.21.0",
     "async": "^2.6.1",
     "natural": "^0.6.1",
     "redis": "^2.8.0",

--- a/samples/productSearch/productSearch.v1p3beta1.js
+++ b/samples/productSearch/productSearch.v1p3beta1.js
@@ -43,18 +43,100 @@ function addProductToProductSet(
     .catch(err => {
       console.error(err);
     });
-
     // [END vision_product_search_add_product_to_product_set]
+  }
+
+function listProductInProductSet(
+    projectId,
+    location,
+    productSetId
+  ) {
+    // [START vision_product_search_list_products_in_product_set]
+
+  const vision = require('@google-cloud/vision').v1p3beta1;
+
+  var client = new vision.ProductSearchClient();
+
+  var productSetPath = client.productSetPath(projectId, location, productSetId);
+
+  var request = {
+    name: productSetPath,
+  };
+  
+  client.addProductToProductSet(request)
+    .then(responses => {
+      var response = responses[0];
+      console.log(`response.name: ${response[0].name}`);
+      console.log(`response.uri: ${response.uri}`);      
+    })
+    .catch(err => {
+      console.error(err);
+    });
+    // [END vision_product_search_list_products_in_product_set]
+  }
+
+  function removeProductFromProductSet(
+    projectId,
+    location,
+    productId,
+    productSetId
+  ) {
+    // [START vision_product_search_remove_product_from_product_set]
+
+  const vision = require('@google-cloud/vision').v1p3beta1;
+
+  var client = new vision.ProductSearchClient();
+
+  var productSetPath = client.productSetPath(projectId, location, productSetId);
+
+  var productPath = client.productPath(projectId, location, productId);
+
+  var request = {
+    name: productSetPath,
+    product: productPath
+  };
+  
+  client.removeProductFromProductSet(request)
+    .then(responses => {
+      console.log(`Product removed from product set.`);      
+    })
+    .catch(err => {
+      console.error(err);
+    });
+    // [END vision_product_search_remove_product_from_product_set]
   }
 
 require(`yargs`) // eslint-disable-line
 .demand(1)
 .command(
   `addProductToProductSet <projectId> <location> <productId> <productSetId>`,
-  `Add a Product to Product Set`,
+  `Add a product to product set`,
   {},
   opts =>
   addProductToProductSet(
+      opts.projectId,
+      opts.location,
+      opts.productId,
+      opts.productSetId
+    )
+)
+.command(
+  `listProductInProductSet <projectId> <location> <productSetId>`,
+  `List all products in a product set`,
+  {},
+  opts =>
+  listProductInProductSet(
+      opts.projectId,
+      opts.location,
+      opts.productSetId
+    )
+)
+.command(
+  `removeProductFromProductSet <projectId> <location> <productId> <productSetId>`,
+  `Remove a products from a product set`,
+  {},
+  opts =>
+  removeProductFromProductSet(
       opts.projectId,
       opts.location,
       opts.productId,

--- a/samples/productSearch/productSearch.v1p3beta1.js
+++ b/samples/productSearch/productSearch.v1p3beta1.js
@@ -27,6 +27,14 @@ function addProductToProductSet(
 
   var client = new vision.ProductSearchClient();
 
+  /**
+   * TODO(developer): Uncomment the following line before running the sample.
+   */
+  // const projectId = 'Your Google Cloud project Id';
+  // const location = 'A compute region name';
+  // const productId = 'Id of the product';
+  // const productSetId = 'Id of the product set';
+  
   var productSetPath = client.productSetPath(projectId, location, productSetId);
 
   var productPath = client.productPath(projectId, location, productId);
@@ -57,6 +65,13 @@ function listProductInProductSet(
 
   var client = new vision.ProductSearchClient();
 
+  /**
+   * TODO(developer): Uncomment the following line before running the sample.
+   */
+  // const projectId = 'Your Google Cloud project Id';
+  // const location = 'A compute region name';
+  // const productSetId = 'Id of the product set';
+
   var productSetPath = client.productSetPath(projectId, location, productSetId);
 
   var request = {
@@ -86,6 +101,14 @@ function listProductInProductSet(
   const vision = require('@google-cloud/vision').v1p3beta1;
 
   var client = new vision.ProductSearchClient();
+
+  /**
+   * TODO(developer): Uncomment the following line before running the sample.
+   */
+  // const projectId = 'Your Google Cloud project Id';
+  // const location = 'A compute region name';
+  // const productId = 'Id of the product';
+  // const productSetId = 'Id of the product set';  
 
   var productSetPath = client.productSetPath(projectId, location, productSetId);
 

--- a/samples/productSearch/productSearch.v1p3beta1.js
+++ b/samples/productSearch/productSearch.v1p3beta1.js
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2018, Google, LLC.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+function addProductToProductSet(
+    projectId,
+    location,
+    productId,
+    productSetId
+  ) {
+    // [START vision_product_search_add_product_to_product_set]
+
+  const vision = require('@google-cloud/vision').v1p3beta1;
+
+  var client = new vision.ProductSearchClient();
+
+  var productSetPath = client.productSetPath(projectId, location, productSetId);
+
+  var productPath = client.productPath(projectId, location, productId);
+
+  var request = {
+    name: productSetPath,
+    product: productPath
+  };
+  
+  client.addProductToProductSet(request)
+    .then(responses => {
+      console.log(`Product added to product set.`);
+    })
+    .catch(err => {
+      console.error(err);
+    });
+
+    // [END vision_product_search_add_product_to_product_set]
+  }
+
+require(`yargs`) // eslint-disable-line
+.demand(1)
+.command(
+  `addProductToProductSet <projectId> <location> <productId> <productSetId>`,
+  `Add a Product to Product Set`,
+  {},
+  opts =>
+  addProductToProductSet(
+      opts.projectId,
+      opts.location,
+      opts.productId,
+      opts.productSetId
+    )
+)
+.example(`node $0 COMMAND ARG`)
+.wrap(120)
+.recommendCommands()
+.epilogue(`For more information, see https://cloud.google.com/vision/docs`)
+.help()
+.strict().argv;

--- a/samples/productSearch/productSets.v1p3beta1.js
+++ b/samples/productSearch/productSets.v1p3beta1.js
@@ -21,7 +21,7 @@ function createProductSet(
   productSetId,
   productSetDisplayName
 ) {
-  // [START product_search_create_product_set]
+  // [START vision_product_search_create_product_set]
   // Imports the Google Cloud client library
   const vision = require('@google-cloud/vision').v1p3beta1;
 
@@ -59,11 +59,11 @@ function createProductSet(
     .catch(err => {
       console.error('ERROR:', err);
     });
-  // [END product_search_create_product_set]
+  // [END vision_product_search_create_product_set]
 }
 
 function getProductSet(projectId, location, productSetId) {
-  // [START product_search_get_product_set]
+  // [START vision_product_search_get_product_set]
   // Imports the Google Cloud client library
   const vision = require('@google-cloud/vision').v1p3beta1;
 
@@ -94,11 +94,11 @@ function getProductSet(projectId, location, productSetId) {
     .catch(err => {
       console.error('ERROR:', err);
     });
-  // [END product_search_get_product_set]
+  // [END vision_product_search_get_product_set]
 }
 
 function listProductSets(projectId, location) {
-  // [START product_search_list_product_sets]
+  // [START vision_product_search_list_product_sets]
   // Imports the Google Cloud client library
   const vision = require('@google-cloud/vision').v1p3beta1;
 
@@ -126,11 +126,11 @@ function listProductSets(projectId, location) {
     .catch(err => {
       console.error('ERROR:', err);
     });
-  // [END product_search_list_product_sets]
+  // [END vision_product_search_list_product_sets]
 }
 
 function deleteProductSet(projectId, location, productSetId) {
-  // [START product_search_delete_product_set]
+  // [START vision_product_search_delete_product_set]
   // Imports the Google Cloud client library
   const vision = require('@google-cloud/vision').v1p3beta1;
 
@@ -159,7 +159,7 @@ function deleteProductSet(projectId, location, productSetId) {
     .catch(err => {
       console.error('ERROR:', err);
     });
-  // [END product_search_delete_product_set]
+  // [END vision_product_search_delete_product_set]
 }
 
 require(`yargs`) // eslint-disable-line

--- a/samples/productSearch/productSets.v1p3beta1.js
+++ b/samples/productSearch/productSets.v1p3beta1.js
@@ -1,0 +1,202 @@
+/**
+ * Copyright 2018, Google, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+function createProductSet(
+  projectId,
+  location,
+  productSetId,
+  productSetDisplayName
+) {
+  // [START product_search_create_product_set]
+  // Imports the Google Cloud client library
+  const vision = require('@google-cloud/vision').v1p3beta1;
+
+  // Creates a client
+  const client = new vision.ProductSearchClient();
+
+  /**
+   * TODO(developer): Uncomment the following line before running the sample.
+   */
+  // const projectId = 'Your Google Cloud project Id';
+  // const location = 'A compute region name';
+  // const productSetId = 'Id of the product set';
+  // const productSetDisplayName = 'Display name of the product set';
+
+  // Resource path that represents Google Cloud Platform location.
+  const locationPath = client.locationPath(projectId, location);
+
+  const productSet = {
+    displayName: productSetDisplayName,
+  };
+
+  const request = {
+    parent: locationPath,
+    productSet: productSet,
+    productSetId: productSetId,
+  };
+
+  client
+    .createProductSet(request)
+    .then(results => {
+      // The response is the product set with the `name` field populated
+      const createdProductSet = results[0];
+      console.log(`Product Set name: ${createdProductSet.name}`);
+    })
+    .catch(err => {
+      console.error('ERROR:', err);
+    });
+  // [END product_search_create_product_set]
+}
+
+function getProductSet(projectId, location, productSetId) {
+  // [START product_search_get_product_set]
+  // Imports the Google Cloud client library
+  const vision = require('@google-cloud/vision').v1p3beta1;
+
+  // Creates a client
+  const client = new vision.ProductSearchClient();
+
+  /**
+   * TODO(developer): Uncomment the following line before running the sample.
+   */
+  // const projectId = 'Your Google Cloud project Id';
+  // const location = 'A compute region name';
+  // const productSetId = 'Id of the product set';
+
+  // Resource path that represents Google Cloud Platform location.
+  const productSetPath = client.productSetPath(
+    projectId,
+    location,
+    productSetId
+  );
+
+  client
+    .getProductSet({name: productSetPath})
+    .then(results => {
+      const productSet = results[0];
+      console.log(`Product Set name: ${productSet.name}`);
+      console.log(`Product Set display name: ${productSet.displayName}`);
+    })
+    .catch(err => {
+      console.error('ERROR:', err);
+    });
+  // [END product_search_get_product_set]
+}
+
+function listProductSets(projectId, location) {
+  // [START product_search_list_product_sets]
+  // Imports the Google Cloud client library
+  const vision = require('@google-cloud/vision').v1p3beta1;
+
+  // Creates a client
+  const client = new vision.ProductSearchClient();
+
+  /**
+   * TODO(developer): Uncomment the following line before running the sample.
+   */
+  // const projectId = 'Your Google Cloud project Id';
+  // const location = 'A compute region name';
+
+  // Resource path that represents Google Cloud Platform location.
+  const locationPath = client.locationPath(projectId, location);
+
+  client
+    .listProductSets({parent: locationPath})
+    .then(results => {
+      const productSets = results[0];
+      productSets.forEach(productSet => {
+        console.log(`Product Set name: ${productSet.name}`);
+        console.log(`Product Set display name: ${productSet.displayName}`);
+      });
+    })
+    .catch(err => {
+      console.error('ERROR:', err);
+    });
+  // [END product_search_list_product_sets]
+}
+
+function deleteProductSet(projectId, location, productSetId) {
+  // [START product_search_delete_product_set]
+  // Imports the Google Cloud client library
+  const vision = require('@google-cloud/vision').v1p3beta1;
+
+  // Creates a client
+  const client = new vision.ProductSearchClient();
+
+  /**
+   * TODO(developer): Uncomment the following line before running the sample.
+   */
+  // const projectId = 'Your Google Cloud project Id';
+  // const location = 'A compute region name';
+  // const productSetId = 'Id of the product set';
+
+  // Resource path that represents full path to the product set.
+  const productSetPath = client.productSetPath(
+    projectId,
+    location,
+    productSetId
+  );
+
+  client
+    .deleteProductSet({name: productSetPath})
+    .then(results => {
+      console.log('Product set deleted.');
+    })
+    .catch(err => {
+      console.error('ERROR:', err);
+    });
+  // [END product_search_delete_product_set]
+}
+
+require(`yargs`) // eslint-disable-line
+  .demand(1)
+  .command(
+    `createProductSet <projectId> <location> <productSetId> <productSetDisplayName>`,
+    `Create product set`,
+    {},
+    opts =>
+      createProductSet(
+        opts.projectId,
+        opts.location,
+        opts.productSetId,
+        opts.productSetDisplayName
+      )
+  )
+  .command(
+    `getProductSet <projectId> <location> <productSetId>`,
+    `Get product set`,
+    {},
+    opts => getProductSet(opts.projectId, opts.location, opts.productSetId)
+  )
+  .command(
+    `listProductSets <projectId> <location>`,
+    `List product sets`,
+    {},
+    opts => listProductSets(opts.projectId, opts.location)
+  )
+  .command(
+    `deleteProductSet <projectId> <location> <productSetId>`,
+    `Delete product set`,
+    {},
+    opts => deleteProductSet(opts.projectId, opts.location, opts.productSetId)
+  )
+  .example(`node $0 COMMAND ARG`)
+  .wrap(120)
+  .recommendCommands()
+  .epilogue(`For more information, see https://cloud.google.com/vision/docs`)
+  .help()
+  .strict().argv;

--- a/samples/productSearch/products.v1p3beta1.js
+++ b/samples/productSearch/products.v1p3beta1.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018, Google, Inc.
+ * Copyright 2018, Google, LLC.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/samples/productSearch/products.v1p3beta1.js
+++ b/samples/productSearch/products.v1p3beta1.js
@@ -1,0 +1,152 @@
+/**
+ * Copyright 2018, Google, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+function createProduct(projectId, location, productId, productDisplayName, productCategory) {
+  // [START product_search_create_product]
+  // Imports the Google Cloud client library
+  const vision = require('@google-cloud/vision').v1p3beta1;
+
+  // Creates a client
+  const client = new vision.ProductSearchClient();
+
+  /**
+   * TODO(developer): Uncomment the following line before running the sample.
+   */
+  // const projectId = 'Your Google Cloud project Id';
+  // const location = 'A compute region name';
+  // const productId = 'Id of the product';
+  // const productDisplayName = 'Display name of the product';
+  // const productCategory = 'Catoegory of the product';
+
+  // Resource path that represents Google Cloud Platform location.
+  const locationPath = client.locationPath(projectId, location);
+
+  const product = {
+    displayName: productDisplayName,
+    productCategory: productCategory,
+  };
+
+  const request = {
+    parent: locationPath,
+    product: product,
+    productId: productId,
+  };
+
+  client
+    .createProduct(request)
+    .then(results => {
+      // The response is the product with the `name` field populated
+      const createdProduct = results[0];
+      console.log(`Product name: ${createdProduct.name}`);
+    })
+    .catch(err => {
+      console.error('ERROR:', err);
+    });
+  // [END product_search_create_product]
+}
+
+function listProducts(projectId, location) {
+  // [START product_search_list_products]
+  // Imports the Google Cloud client library
+  const vision = require('@google-cloud/vision').v1p3beta1;
+
+  // Creates a client
+  const client = new vision.ProductSearchClient();
+
+  /**
+   * TODO(developer): Uncomment the following line before running the sample.
+   */
+  // const projectId = 'Your Google Cloud project Id';
+  // const location = 'A compute region name';
+
+  // Resource path that represents Google Cloud Platform location.
+  const locationPath = client.locationPath(projectId, location);
+
+  client
+    .listProducts({parent: locationPath})
+    .then(results => {
+      const products = results[0];
+      products.forEach(product => {
+        console.log(`Product name: ${product.name}`);
+        console.log(`Product id: ${product.name.split('/').pop()}`);
+        console.log(`Product display name: ${product.displayName}`);
+        console.log(`Product description: ${product.description}`);
+        console.log(`Product category: ${product.productCategory}`);
+        console.log(`Product labels: ${product.productLabels}`);
+      });
+    })
+    .catch(err => {
+      console.error('ERROR:', err);
+    });
+  // [END product_search_list_products]
+}
+
+function deleteProduct(projectId, location, productId) {
+  // [START product_search_delete_product]
+  // Imports the Google Cloud client library
+  const vision = require('@google-cloud/vision').v1p3beta1;
+
+  // Creates a client
+  const client = new vision.ProductSearchClient();
+
+  /**
+   * TODO(developer): Uncomment the following line before running the sample.
+   */
+  // const projectId = 'Your Google Cloud project Id';
+  // const location = 'A compute region name';
+  // const productId = 'Id of the product';
+
+  // Resource path that represents full path to the product.
+  const productPath = client.productPath(projectId, location, productId);
+
+  client
+    .deleteProduct({name: productPath})
+    .then(results => {
+      console.log('Product deleted.');
+    })
+    .catch(err => {
+      console.error('ERROR:', err);
+    });
+  // [END product_search_delete_product]
+}
+
+require(`yargs`) // eslint-disable-line
+  .demand(1)
+  .command(
+    `createProduct <projectId> <location> <productId> <productDisplayName> <productCategory>`,
+    `Create product`,
+    {},
+    opts => createProduct(opts.projectId, opts.location, opts.productId, opts.productDisplayName, opts.productCategory)
+  )
+  .command(
+    `listProducts <projectId> <location>`,
+    `List products`,
+    {},
+    opts => listProducts(opts.projectId, opts.location)
+  )
+  .command(
+    `deleteProduct <projectId> <location> <productId>`,
+    `Delete product`,
+    {},
+    opts => deleteProduct(opts.projectId, opts.location, opts.productId)
+  )
+  .example(`node $0 COMMAND ARG`)
+  .wrap(120)
+  .recommendCommands()
+  .epilogue(`For more information, see https://cloud.google.com/vision/docs`)
+  .help()
+  .strict().argv;

--- a/samples/productSearch/products.v1p3beta1.js
+++ b/samples/productSearch/products.v1p3beta1.js
@@ -165,6 +165,59 @@ function deleteProduct(projectId, location, productId) {
   // [END vision_product_search_delete_product]
 }
 
+function updateProductLabels(projectId, location, productId, key, value) {
+  // [START vision_product_search_update_product_labels]
+  // Imports the Google Cloud client library
+  const vision = require('@google-cloud/vision').v1p3beta1;
+
+  // Creates a client
+  const client = new vision.ProductSearchClient();
+
+  /**
+   * TODO(developer): Uncomment the following line before running the sample.
+   */
+  // const projectId = 'Your Google Cloud project Id';
+  // const location = 'A compute region name';
+  // const productId = 'Id of the product';
+  // const key = 'The key of the label';
+  // const value = 'The value of the label';
+
+  // Resource path that represents full path to the product.
+  const productPath = client.productPath(projectId, location, productId);
+
+  const product = {
+    name: productPath,
+    productLabels: [{
+      key: key,
+      value: value,
+    }]
+  };
+
+  const updateMask = {
+    paths: ['product_labels'],
+  };
+
+  const request = {
+    product: product,
+    updateMask: updateMask,
+  };  
+
+  client
+    .updateProduct(request)
+    .then(results => {
+      var product = results[0];
+      console.log(`Product name: ${product.name}`);
+      console.log(`Product display name: ${product.displayName}`);
+      console.log(`Product description: ${product.description}`);
+      console.log(`Product category: ${product.productCategory}`);
+      console.log(`Product Labels: ${product.productLabels[0].key}: ${product.productLabels[0].value}`);
+  })
+    .catch(err => {
+      console.error('ERROR:', err);
+    });
+  // [END vision_product_search_update_product_labels]
+}
+
 require(`yargs`) // eslint-disable-line
   .demand(1)
   .command(
@@ -194,6 +247,12 @@ require(`yargs`) // eslint-disable-line
     `Delete product`,
     {},
     opts => deleteProduct(opts.projectId, opts.location, opts.productId)
+  )
+  .command(
+    `updateProductLabels <projectId> <location> <productId> <key> <value>`,
+    `Update product label`,
+    {},
+    opts => updateProductLabels(opts.projectId, opts.location, opts.productId, opts.key, opts.value)
   )
   .example(`node $0 COMMAND ARG`)
   .wrap(120)

--- a/samples/productSearch/products.v1p3beta1.js
+++ b/samples/productSearch/products.v1p3beta1.js
@@ -15,7 +15,13 @@
 
 'use strict';
 
-function createProduct(projectId, location, productId, productDisplayName, productCategory) {
+function createProduct(
+  projectId,
+  location,
+  productId,
+  productDisplayName,
+  productCategory
+) {
   // [START product_search_create_product]
   // Imports the Google Cloud client library
   const vision = require('@google-cloud/vision').v1p3beta1;
@@ -130,13 +136,17 @@ require(`yargs`) // eslint-disable-line
     `createProduct <projectId> <location> <productId> <productDisplayName> <productCategory>`,
     `Create product`,
     {},
-    opts => createProduct(opts.projectId, opts.location, opts.productId, opts.productDisplayName, opts.productCategory)
+    opts =>
+      createProduct(
+        opts.projectId,
+        opts.location,
+        opts.productId,
+        opts.productDisplayName,
+        opts.productCategory
+      )
   )
-  .command(
-    `listProducts <projectId> <location>`,
-    `List products`,
-    {},
-    opts => listProducts(opts.projectId, opts.location)
+  .command(`listProducts <projectId> <location>`, `List products`, {}, opts =>
+    listProducts(opts.projectId, opts.location)
   )
   .command(
     `deleteProduct <projectId> <location> <productId>`,

--- a/samples/productSearch/products.v1p3beta1.js
+++ b/samples/productSearch/products.v1p3beta1.js
@@ -65,6 +65,41 @@ function createProduct(
   // [END product_search_create_product]
 }
 
+function getProduct(projectId, location, productId) {
+  // [START product_search_get_product]
+  // Imports the Google Cloud client library
+  const vision = require('@google-cloud/vision').v1p3beta1;
+
+  // Creates a client
+  const client = new vision.ProductSearchClient();
+
+  /**
+   * TODO(developer): Uncomment the following line before running the sample.
+   */
+  // const projectId = 'Your Google Cloud project Id';
+  // const location = 'A compute region name';
+  // const productId = 'Id of the product';
+
+  // Resource path that represents Google Cloud Platform location.
+  const productPath = client.productPath(projectId, location, productId);
+
+  client
+    .getProduct({name: productPath})
+    .then(results => {
+      const product = results[0];
+      console.log(`Product name: ${product.name}`);
+      console.log(`Product id: ${product.name.split('/').pop()}`);
+      console.log(`Product display name: ${product.displayName}`);
+      console.log(`Product description: ${product.description}`);
+      console.log(`Product category: ${product.productCategory}`);
+      console.log(`Product labels: ${product.productLabels}`);
+    })
+    .catch(err => {
+      console.error('ERROR:', err);
+    });
+  // [END product_search_get_product]
+}
+
 function listProducts(projectId, location) {
   // [START product_search_list_products]
   // Imports the Google Cloud client library
@@ -144,6 +179,12 @@ require(`yargs`) // eslint-disable-line
         opts.productDisplayName,
         opts.productCategory
       )
+  )
+  .command(
+    `getProduct <projectId> <location> <productId>`,
+    `Get product`,
+    {},
+    opts => getProduct(opts.projectId, opts.location, opts.productId)
   )
   .command(`listProducts <projectId> <location>`, `List products`, {}, opts =>
     listProducts(opts.projectId, opts.location)

--- a/samples/productSearch/products.v1p3beta1.js
+++ b/samples/productSearch/products.v1p3beta1.js
@@ -22,7 +22,7 @@ function createProduct(
   productDisplayName,
   productCategory
 ) {
-  // [START product_search_create_product]
+  // [START vision_product_search_create_product]
   // Imports the Google Cloud client library
   const vision = require('@google-cloud/vision').v1p3beta1;
 
@@ -62,11 +62,11 @@ function createProduct(
     .catch(err => {
       console.error('ERROR:', err);
     });
-  // [END product_search_create_product]
+  // [END vision_product_search_create_product]
 }
 
 function getProduct(projectId, location, productId) {
-  // [START product_search_get_product]
+  // [START vision_product_search_get_product]
   // Imports the Google Cloud client library
   const vision = require('@google-cloud/vision').v1p3beta1;
 
@@ -97,11 +97,11 @@ function getProduct(projectId, location, productId) {
     .catch(err => {
       console.error('ERROR:', err);
     });
-  // [END product_search_get_product]
+  // [END vision_product_search_get_product]
 }
 
 function listProducts(projectId, location) {
-  // [START product_search_list_products]
+  // [START vision_product_search_list_products]
   // Imports the Google Cloud client library
   const vision = require('@google-cloud/vision').v1p3beta1;
 
@@ -133,11 +133,11 @@ function listProducts(projectId, location) {
     .catch(err => {
       console.error('ERROR:', err);
     });
-  // [END product_search_list_products]
+  // [END vision_product_search_list_products]
 }
 
 function deleteProduct(projectId, location, productId) {
-  // [START product_search_delete_product]
+  // [START vision_product_search_delete_product]
   // Imports the Google Cloud client library
   const vision = require('@google-cloud/vision').v1p3beta1;
 
@@ -162,7 +162,7 @@ function deleteProduct(projectId, location, productId) {
     .catch(err => {
       console.error('ERROR:', err);
     });
-  // [END product_search_delete_product]
+  // [END vision_product_search_delete_product]
 }
 
 require(`yargs`) // eslint-disable-line

--- a/samples/productSearch/referenceImages.v1p3beta1.js
+++ b/samples/productSearch/referenceImages.v1p3beta1.js
@@ -58,6 +58,49 @@ function createReferenceImage(
     // [END vision_product_search_create_reference_image]
   }
 
+
+  function getReferenceImage(
+    projectId,
+    location,
+    productId,
+    referenceImageId
+  ) {
+    // [START vision_product_search_get_reference_image]
+
+  const vision = require('@google-cloud/vision').v1p3beta1;
+
+  var client = new vision.ProductSearchClient({
+    // optional auth parameters.
+  });
+
+  var formattedParent = client.productPath(projectId, location, productId);
+
+  var referenceImage = {
+      uri: gcsUri
+  };
+
+  var referenceImageId = '';
+
+  var formattedName = client.referenceImagePath(projectId, location, productId, referenceImageId);
+  
+  var request = {
+    name: formattedName,
+  };
+  
+  client.getReferenceImage(request)
+    .then(responses => {
+      var response = responses[0];
+      console.log(`response.boundingPolys: ${response.boundingPolys}`);
+      console.log(`response.name: ${response.name}`);
+      console.log(`response.uri: ${response.uri}`);
+    })
+    .catch(err => {
+      console.err(err);
+    });
+
+    // [END vision_product_search_get_reference_image]
+  }
+
 require(`yargs`) // eslint-disable-line
 .demand(1)
 .command(
@@ -71,6 +114,18 @@ require(`yargs`) // eslint-disable-line
       opts.productId,
       opts.referenceImageId,
       opts.gcsUri
+    )
+)
+.command(
+  `getReferenceImage <projectId> <location> <productId> <referenceImageId>`,
+  `Get Reference Image`,
+  {},
+  opts =>
+    createReferenceImage(
+      opts.projectId,
+      opts.location,
+      opts.productId,
+      opts.referenceImageId
     )
 )
 .example(`node $0 COMMAND ARG`)

--- a/samples/productSearch/referenceImages.v1p3beta1.js
+++ b/samples/productSearch/referenceImages.v1p3beta1.js
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2018, Google, LLC.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+function createReferenceImage(
+    projectId,
+    location,
+    productId,
+    referenceImageId,
+    gcsUri
+  ) {
+    // [START vision_product_search_create_reference_image]
+
+  const vision = require('@google-cloud/vision').v1p3beta1;
+
+  var client = new vision.ProductSearchClient({
+    // optional auth parameters.
+  });
+
+  var formattedParent = client.productPath(projectId, location, productId);
+
+  var referenceImage = {
+      uri: gcsUri
+  };
+
+  var referenceImageId = '';
+  
+  var request = {
+    parent: formattedParent,
+    referenceImage: referenceImage,
+    referenceImageId: referenceImageId,
+  };
+  
+  client.createReferenceImage(request)
+    .then(responses => {
+      var response = responses[0];
+      console.log(`response.boundingPolys: ${response.boundingPolys}`);
+      console.log(`response.name: ${response.name}`);
+      console.log(`response.uri: ${response.uri}`);
+    })
+    .catch(err => {
+      console.err(err);
+    });
+
+    // [END vision_product_search_create_reference_image]
+  }
+
+require(`yargs`) // eslint-disable-line
+.demand(1)
+.command(
+  `createReferenceImage <projectId> <location> <productId> <referenceImageId> <gcsUri>`,
+  `Create Reference Image`,
+  {},
+  opts =>
+    createReferenceImage(
+      opts.projectId,
+      opts.location,
+      opts.productId,
+      opts.referenceImageId,
+      opts.gcsUri
+    )
+)
+.example(`node $0 COMMAND ARG`)
+.wrap(120)
+.recommendCommands()
+.epilogue(`For more information, see https://cloud.google.com/vision/docs`)
+.help()
+.strict().argv;

--- a/samples/productSearch/referenceImages.v1p3beta1.js
+++ b/samples/productSearch/referenceImages.v1p3beta1.js
@@ -28,6 +28,15 @@ function createReferenceImage(
 
   var client = new vision.ProductSearchClient();
 
+  /**
+   * TODO(developer): Uncomment the following line before running the sample.
+   */
+  // const projectId = 'Your Google Cloud project Id';
+  // const location = 'A compute region name';
+  // const productId = 'Id of the product';
+  // const referenceImageId = 'Id of the reference image';
+  // const gcsUri = 'Google Cloud Storage path of the input image';
+
   var formattedParent = client.productPath(projectId, location, productId);
 
   var referenceImage = {
@@ -64,6 +73,13 @@ function createReferenceImage(
 
   var client = new vision.ProductSearchClient();
 
+  /**
+   * TODO(developer): Uncomment the following line before running the sample.
+   */
+  // const projectId = 'Your Google Cloud project Id';
+  // const location = 'A compute region name';
+  // const productId = 'Id of the product';
+
   var formattedParent = client.productPath(projectId, location, productId);
 
   var request = {
@@ -97,6 +113,14 @@ function createReferenceImage(
 
   var client = new vision.ProductSearchClient();
 
+  /**
+   * TODO(developer): Uncomment the following line before running the sample.
+   */
+  // const projectId = 'Your Google Cloud project Id';
+  // const location = 'A compute region name';
+  // const productId = 'Id of the product';
+  // const referenceImageId = 'Id of the reference image';
+  
   var formattedName = client.referenceImagePath(projectId, location, productId, referenceImageId);
 
   var request = {
@@ -128,6 +152,14 @@ function createReferenceImage(
 
   var client = new vision.ProductSearchClient();
 
+  /**
+   * TODO(developer): Uncomment the following line before running the sample.
+   */
+  // const projectId = 'Your Google Cloud project Id';
+  // const location = 'A compute region name';
+  // const productId = 'Id of the product';
+  // const referenceImageId = 'Id of the reference image';
+  
   var formattedName = client.referenceImagePath(projectId, location, productId, referenceImageId);
 
   var request = {

--- a/samples/productSearch/referenceImages.v1p3beta1.js
+++ b/samples/productSearch/referenceImages.v1p3beta1.js
@@ -26,9 +26,7 @@ function createReferenceImage(
 
   const vision = require('@google-cloud/vision').v1p3beta1;
 
-  var client = new vision.ProductSearchClient({
-    // optional auth parameters.
-  });
+  var client = new vision.ProductSearchClient();
 
   var formattedParent = client.productPath(projectId, location, productId);
 
@@ -36,8 +34,6 @@ function createReferenceImage(
       uri: gcsUri
   };
 
-  var referenceImageId = '';
-  
   var request = {
     parent: formattedParent,
     referenceImage: referenceImage,
@@ -47,17 +43,47 @@ function createReferenceImage(
   client.createReferenceImage(request)
     .then(responses => {
       var response = responses[0];
-      console.log(`response.boundingPolys: ${response.boundingPolys}`);
       console.log(`response.name: ${response.name}`);
       console.log(`response.uri: ${response.uri}`);
     })
     .catch(err => {
-      console.err(err);
+      console.error(err);
     });
 
     // [END vision_product_search_create_reference_image]
   }
 
+  function listReferenceImage(
+    projectId,
+    location,
+    productId
+  ) {
+    // [START vision_product_search_list_reference_images]
+
+  const vision = require('@google-cloud/vision').v1p3beta1;
+
+  var client = new vision.ProductSearchClient();
+
+  var formattedParent = client.productPath(projectId, location, productId);
+
+  var request = {
+    parent: formattedParent,
+  };
+  
+  client.listReferenceImages(request)
+    .then(responses => {
+      var response = responses[0];
+      response.forEach(image => {
+        console.log(`image.name: ${image.name}`);
+        console.log(`image.uri: ${image.uri}`);  
+      });
+    })
+    .catch(err => {
+      console.log(err);
+    });
+
+    // [END vision_product_search_list_reference_images]
+  }
 
   function getReferenceImage(
     projectId,
@@ -69,20 +95,10 @@ function createReferenceImage(
 
   const vision = require('@google-cloud/vision').v1p3beta1;
 
-  var client = new vision.ProductSearchClient({
-    // optional auth parameters.
-  });
-
-  var formattedParent = client.productPath(projectId, location, productId);
-
-  var referenceImage = {
-      uri: gcsUri
-  };
-
-  var referenceImageId = '';
+  var client = new vision.ProductSearchClient();
 
   var formattedName = client.referenceImagePath(projectId, location, productId, referenceImageId);
-  
+
   var request = {
     name: formattedName,
   };
@@ -90,16 +106,44 @@ function createReferenceImage(
   client.getReferenceImage(request)
     .then(responses => {
       var response = responses[0];
-      console.log(`response.boundingPolys: ${response.boundingPolys}`);
       console.log(`response.name: ${response.name}`);
       console.log(`response.uri: ${response.uri}`);
     })
     .catch(err => {
-      console.err(err);
+      console.log(err);
     });
 
     // [END vision_product_search_get_reference_image]
   }
+
+  function deleteReferenceImage(
+    projectId,
+    location,
+    productId,
+    referenceImageId
+  ) {
+    // [START vision_product_search_delete_reference_image]
+
+  const vision = require('@google-cloud/vision').v1p3beta1;
+
+  var client = new vision.ProductSearchClient();
+
+  var formattedName = client.referenceImagePath(projectId, location, productId, referenceImageId);
+
+  var request = {
+    name: formattedName,
+  };
+  
+  client.deleteReferenceImage(request)
+    .then(responses => {
+      console.log(`Reference image deleted from product.`);  
+    })
+    .catch(err => {
+      console.log(err);
+    });
+
+    // [END vision_product_search_delete_reference_image]
+  }  
 
 require(`yargs`) // eslint-disable-line
 .demand(1)
@@ -117,11 +161,34 @@ require(`yargs`) // eslint-disable-line
     )
 )
 .command(
+  `listReferenceImages <projectId> <location> <productId>`,
+  `List Reference Images`,
+  {},
+  opts =>
+    listReferenceImages(
+      opts.projectId,
+      opts.location,
+      opts.productId
+    )
+)
+.command(
   `getReferenceImage <projectId> <location> <productId> <referenceImageId>`,
   `Get Reference Image`,
   {},
   opts =>
-    createReferenceImage(
+    getReferenceImage(
+      opts.projectId,
+      opts.location,
+      opts.productId,
+      opts.referenceImageId
+    )
+)
+.command(
+  `deleteReferenceImage <projectId> <location> <productId> <referenceImageId>`,
+  `Delete Reference Image`,
+  {},
+  opts =>
+    deleteReferenceImage(
       opts.projectId,
       opts.location,
       opts.productId,

--- a/samples/productSearch/system-test/.eslintrc.yml
+++ b/samples/productSearch/system-test/.eslintrc.yml
@@ -1,0 +1,5 @@
+---
+rules:
+  node/no-unpublished-require: off
+  node/no-unsupported-features: off
+  no-empty: off

--- a/samples/productSearch/system-test/productSearch.v1p3beta1.test.js
+++ b/samples/productSearch/system-test/productSearch.v1p3beta1.test.js
@@ -95,9 +95,20 @@ test(`should add product to product set`, async t => {
     cwd
   );
 
+  t.true(output.includes(`Product added to product set.`));
+});
+
+test(`remove a product from a product set`, async t => {
+  const output = await tools.runAsync(
+    `${cmd} removeProductFromProductSet "${testProductSet.projectId}" "${
+      testProductSet.location}" "${testProductSet.productId}" "${
+        testProductSet.productSetId}"`,
+    cwd
+  );
+
   console.log('---------------');
   console.log(output);
   console.log('---------------');
 
-  t.true(output.includes(`Product added to product set.`));
+  t.true(output.includes(`Product removed from product set.`));
 });

--- a/samples/productSearch/system-test/productSearch.v1p3beta1.test.js
+++ b/samples/productSearch/system-test/productSearch.v1p3beta1.test.js
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2018, Google, LLC.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const path = require(`path`);
+const uuid = require(`uuid`);
+const vision = require('@google-cloud/vision').v1p3beta1;
+const productSearchClient = new vision.ProductSearchClient();
+const test = require(`ava`);
+const tools = require(`@google-cloud/nodejs-repo-tools`);
+const cmd = `node productSearch.v1p3beta1.js`;
+const cwd = path.join(__dirname, `..`);
+
+// Shared fixture data for product tests
+var testProductSet = {
+  projectId: process.env.GCLOUD_PROJECT,
+  location: 'us-west1',
+  productCategory: 'homegoods',
+  productId: 'test_product_id_1',
+  productSetId: 'test_product_set_id_1',
+  productSetDisplayName: 'test_product_set_display_name_1',
+};
+
+testProductSet.productSetPath = productSearchClient.productSetPath(
+  testProductSet.projectId,
+  testProductSet.location,
+  testProductSet.productSetId
+);
+
+testProductSet.createdProductPaths = [];
+testProductSet.createdProductSetPaths = [];
+
+test.before(tools.checkCredentials);
+
+test.before(async () => {
+  // Create a test product set for each test
+  try {
+    await productSearchClient.createProduct({
+      parent: productSearchClient.locationPath(
+        testProductSet.projectId,
+        testProductSet.location
+      ),
+      productId: testProductSet.productId,
+      product: {
+        displayName: testProductSet.productDisplayName,
+        productCategory: testProductSet.productCategory,
+      },
+    });
+    testProductSet.createdProductPaths.push(testProduct.productPath);
+  } catch (err) {} // ignore error
+
+    try {
+      await productSearchClient.createProductSet({
+      parent: productSearchClient.locationPath(
+        testProductSet.projectId,
+        testProductSet.location
+      ),
+      productSetId: testProductSet.productSetId,
+      productSet: {
+        displayName: testProductSet.productSetDisplayName,
+      },
+    });
+    testProductSet.createdProductSetPaths.push(testProductSet.createdProductSetPaths);
+  } catch (err) {} // ignore error
+});
+
+test.after(async () => {
+  // Delete products sets after each test
+  testProductSet.createdProductSetPaths.forEach(async path => {
+    try {
+      await productSearchClient.deleteProductSet({name: path});
+      await productSearchClient.deleteProduct({name: path});
+    } catch (err) {} // ignore error
+  });
+});
+
+test(`should add product to product set`, async t => {
+  const output = await tools.runAsync(
+    `${cmd} addProductToProductSet "${testProductSet.projectId}" "${
+      testProductSet.location}" "${testProductSet.productId}" "${
+        testProductSet.productSetId}"`,
+    cwd
+  );
+
+  console.log('---------------');
+  console.log(output);
+  console.log('---------------');
+
+  t.true(output.includes(`Product added to product set.`));
+});

--- a/samples/productSearch/system-test/productSets.v1p3beta1.test.js
+++ b/samples/productSearch/system-test/productSets.v1p3beta1.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018, Google, Inc.
+ * Copyright 2018, Google, LLC.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/samples/productSearch/system-test/productSets.v1p3beta1.test.js
+++ b/samples/productSearch/system-test/productSets.v1p3beta1.test.js
@@ -1,0 +1,144 @@
+/**
+ * Copyright 2018, Google, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const path = require(`path`);
+const uuid = require(`uuid`);
+const vision = require('@google-cloud/vision').v1p3beta1;
+const productSearch = new vision.ProductSearchClient();
+const test = require(`ava`);
+const tools = require(`@google-cloud/nodejs-repo-tools`);
+const cmd = `node productSets.v1p3beta1.js`;
+const cwd = path.join(__dirname, `..`);
+
+// Shared fixture data for product tests
+const testProductSet = {
+  projectId: process.env.GCLOUD_PROJECT,
+  location: 'us-west1',
+  productSetId: 'test_product_set_id_1',
+  productSetDisplayName: 'test_product_set_display_name_1',
+};
+testProductSet.productSetPath = productSearch.productSetPath(
+  testProductSet.projectId,
+  testProductSet.location,
+  testProductSet.productSetId
+);
+testProductSet.createdProductSetPaths = [];
+
+// Helper function: returns product set if exists else false
+async function getProductSetOrFalse(productSetPath) {
+  try {
+    const response = await productSearch.getProductSet({name: productSetPath});
+    return response[0];
+  } catch (err) {
+    if (err.message.includes('Not found')) {
+      return false;
+    } else {
+      throw err;
+    }
+  }
+}
+
+test.before(tools.checkCredentials);
+test.before(async () => {
+  // Create a test product set for each test
+  try {
+    await productSearch.createProductSet({
+      parent: productSearch.locationPath(
+        testProductSet.projectId,
+        testProductSet.location
+      ),
+      productSetId: testProductSet.productSetId,
+      productSet: {
+        displayName: testProductSet.productSetDisplayName,
+      },
+    });
+    testProductSet.createdProductSetPaths.push(testProductSet.createdProductSetPaths);
+  } catch (err) {} // ignore error
+});
+test.after(async () => {
+  // Delete products sets after each test
+  testProductSet.createdProductSetPaths.forEach(async path => {
+    try {
+      await productSearch.deleteProductSet({name: path});
+    } catch (err) {} // ignore error
+  });
+});
+
+test(`should create product set`, async t => {
+  var newProductSetId = `ProductSetId${uuid.v4()}`;
+  var newProductSetPath = productSearch.productSetPath(
+    testProductSet.projectId,
+    testProductSet.location,
+    newProductSetId
+  );
+  t.falsy(await getProductSetOrFalse(newProductSetPath));
+  testProductSet.createdProductSetPaths.push(newProductSetPath);
+
+  const output = await tools.runAsync(
+    `${cmd} createProductSet "${testProductSet.projectId}" "${testProductSet.location}" "${newProductSetId}" "${testProductSet.productSetDisplayName}"`,
+    cwd
+  );
+
+  t.true(output.includes(`Product Set name: ${newProductSetPath}`));
+
+  const newProductSet = await getProductSetOrFalse(newProductSetPath);
+  t.true(newProductSet.displayName == testProductSet.productSetDisplayName);
+});
+
+test(`should get product set`, async t => {
+  const output = await tools.runAsync(
+    `${cmd} getProductSet "${testProductSet.projectId}" "${testProductSet.location}" "${testProductSet.productSetId}"`,
+    cwd
+  );
+
+  t.true(output.includes(`Product Set name: ${testProductSet.productSetPath}`));
+  t.true(output.includes(`Product Set display name: ${testProductSet.productSetDisplayName}`));
+});
+
+test(`should list product sets`, async t => {
+  const output = await tools.runAsync(
+    `${cmd} listProductSets "${testProductSet.projectId}" "${testProductSet.location}"`,
+    cwd
+  );
+
+  t.true(output.includes(`Product Set name: ${testProductSet.productSetPath}`));
+  t.true(
+    output.includes(`Product Set display name: ${testProductSet.productSetDisplayName}`)
+  );
+});
+
+test(`should delete product sets`, async t => {
+  const productSet = await productSearch.getProductSet({
+    name: `${testProductSet.productSetPath}`,
+  });
+  t.truthy(productSet);
+
+  const output = await tools.runAsync(
+    `${cmd} deleteProductSet "${testProductSet.projectId}" "${
+      testProductSet.location
+    }" "${testProductSet.productSetId}"`,
+    cwd
+  );
+
+  t.true(output.includes('deleted'));
+  try {
+    await productSearch.getProductSet({name: `${testProductSet.productSetPath}`});
+    t.fail('Product set was not deleted');
+  } catch (err) {
+    t.true(err.message.includes('Not found'));
+  }
+});

--- a/samples/productSearch/system-test/products.v1p3beta1.test.js
+++ b/samples/productSearch/system-test/products.v1p3beta1.test.js
@@ -128,17 +128,9 @@ test(`should list products`, async t => {
     cwd
   );
 
-  t.true(
-    output.includes(
-      `Product name: projects/${testProduct.projectId}/locations/${
-        testProduct.location
-      }/products/${testProduct.productId}`
-    )
-  );
+  t.true(output.includes(`Product name: ${testProduct.productPath}`));
   t.true(output.includes(`Product id: ${testProduct.productId}`));
-  t.true(
-    output.includes(`Product display name: ${testProduct.productDisplayName}`)
-  );
+  t.true(output.includes(`Product display name: ${testProduct.productDisplayName}`));
   t.true(output.includes(`Product description:`));
   t.true(output.includes(`Product category: ${testProduct.productCategory}`));
   t.true(output.includes(`Product labels:`));

--- a/samples/productSearch/system-test/products.v1p3beta1.test.js
+++ b/samples/productSearch/system-test/products.v1p3beta1.test.js
@@ -21,7 +21,7 @@ const vision = require('@google-cloud/vision').v1p3beta1;
 const productSearch = new vision.ProductSearchClient();
 const test = require(`ava`);
 const tools = require(`@google-cloud/nodejs-repo-tools`);
-const cmd = `node productSearch/products.v1p3beta1.js`;
+const cmd = `node products.v1p3beta1.js`;
 const cwd = path.join(__dirname, `..`);
 
 // Shared fixture data for product tests

--- a/samples/productSearch/system-test/products.v1p3beta1.test.js
+++ b/samples/productSearch/system-test/products.v1p3beta1.test.js
@@ -31,6 +31,8 @@ const testProduct = {
   productId: 'test_product_id_1',
   productDisplayName: 'test_product_display_name_1',
   productCategory: 'homegoods',
+  productKey: 'myKey',
+  productValue: 'myValue',
 };
 testProduct.productPath = productSearch.productPath(
   testProduct.projectId,
@@ -155,4 +157,17 @@ test(`should delete product`, async t => {
   } catch (err) {
     t.true(err.message.includes('Not found'));
   }
+});
+
+test(`should update product label`, async t => {
+  const output = await tools.runAsync(
+    `${cmd} updateProductLabels "${testProduct.projectId}" "${testProduct.location}" "${
+      testProduct.productId}" "${testProduct.productKey}" "${testProduct.productValue}"`,
+    cwd
+  );
+
+  t.true(output.includes(`Product Labels: ${testProduct.productKey}: ${testProduct.productValue}`));
+  t.true(output.includes(`Product display name: ${testProduct.productDisplayName}`));
+  t.true(output.includes(`Product description:`));
+  t.true(output.includes(`Product category: ${testProduct.productCategory}`));
 });

--- a/samples/productSearch/system-test/referenceImages.v1p3beta1.test.js
+++ b/samples/productSearch/system-test/referenceImages.v1p3beta1.test.js
@@ -41,20 +41,6 @@ testProduct.productPath = productSearchClient.productPath(
 );
 testProduct.createdProductPaths = [];
 
-// Helper function: returns product if exists else false
-async function getProductOrFalse(productPath) {
-  try {
-    const response = await productSearchClient.getProduct({name: productPath});
-    return response[0];
-  } catch (err) {
-    if (err.message.includes('Not found')) {
-      return false;
-    } else {
-      throw err;
-    }
-  }
-}
-
 test.before(tools.checkCredentials);
 
 test.before(async () => {
@@ -91,6 +77,7 @@ test(`should create reference image`, async t => {
         testProduct.productReferenceImageId}" "${testProduct.productImageUri}"`,
     cwd
   );
+  
   t.true(output.includes(`response.uri: gs://`));
 });
 
@@ -101,10 +88,6 @@ test(`should delete reference image`, async t => {
         testProduct.productReferenceImageId}"`,
     cwd
   );
-
-  console.log('------------------------');
-  console.log(output);
-  console.log('------------------------');
 
   t.true(output.includes(`Reference image deleted from product.`));
 });

--- a/samples/productSearch/system-test/referenceImages.v1p3beta1.test.js
+++ b/samples/productSearch/system-test/referenceImages.v1p3beta1.test.js
@@ -21,7 +21,7 @@ const vision = require('@google-cloud/vision').v1p3beta1;
 const productSearch = new vision.ProductSearchClient();
 const test = require(`ava`);
 const tools = require(`@google-cloud/nodejs-repo-tools`);
-const cmd = `node products.v1p3beta1.js`;
+const cmd = `node referenceImages.v1p3beta1.js`;
 const cwd = path.join(__dirname, `..`);
 
 // Shared fixture data for product tests
@@ -31,6 +31,8 @@ const testProduct = {
   productId: 'test_product_id_1',
   productDisplayName: 'test_product_display_name_1',
   productCategory: 'homegoods',
+  productReferenceImageId: 'referenceImageId1234',
+  productImageUri: 'gs://python-docs-samples-tests/product_search/shoes_1.jpg',
 };
 testProduct.productPath = productSearch.productPath(
   testProduct.projectId,
@@ -80,7 +82,7 @@ test.after(async () => {
   });
 });
 
-test(`should create product`, async t => {
+test(`should create reference image`, async t => {
   var newProductId = `ProductId${uuid.v4()}`;
   var newProductPath = productSearch.productPath(
     testProduct.projectId,
@@ -91,68 +93,11 @@ test(`should create product`, async t => {
   testProduct.createdProductPaths.push(newProductPath);
 
   const output = await tools.runAsync(
-    `${cmd} createProduct "${testProduct.projectId}" "${
-      testProduct.location
-    }" "${newProductId}" "${testProduct.productDisplayName}" "${
-      testProduct.productCategory
-    }"`,
+    `${cmd} createReferenceImage "${testProduct.projectId}" "${
+        testProduct.location}" "${testProduct.productId}" "${
+        testProduct.productReferenceImageId}" "${testProduct.productImageUri}"`,
     cwd
   );
 
-  t.true(output.includes(`Product name: ${newProductPath}`));
-
-  const newProduct = await getProductOrFalse(newProductPath);
-  t.true(newProduct.displayName == testProduct.productDisplayName);
-  t.true(newProduct.productCategory == testProduct.productCategory);
-});
-
-test(`should get product`, async t => {
-  const output = await tools.runAsync(
-    `${cmd} getProduct "${testProduct.projectId}" "${testProduct.location}" "${
-      testProduct.productId
-    }"`,
-    cwd
-  );
-
-  t.true(output.includes(`Product name: ${testProduct.productPath}`));
-  t.true(output.includes(`Product id: ${testProduct.productId}`));
-  t.true(output.includes(`Product display name:`));
-  t.true(output.includes(`Product description:`));
-  t.true(output.includes(`Product category: ${testProduct.productCategory}`));
-  t.true(output.includes(`Product labels:`));
-});
-
-test(`should list products`, async t => {
-  const output = await tools.runAsync(
-    `${cmd} listProducts "${testProduct.projectId}" "${testProduct.location}"`,
-    cwd
-  );
-
-  t.true(output.includes(`Product name: ${testProduct.productPath}`));
-  t.true(output.includes(`Product id: ${testProduct.productId}`));
-  t.true(output.includes(`Product display name: ${testProduct.productDisplayName}`));
-  t.true(output.includes(`Product description:`));
-  t.true(output.includes(`Product category: ${testProduct.productCategory}`));
-  t.true(output.includes(`Product labels:`));
-});
-
-test(`should delete product`, async t => {
-  const product = await productSearch.getProduct({
-    name: `${testProduct.productPath}`,
-  });
-  t.truthy(product);
-
-  const output = await tools.runAsync(
-    `${cmd} deleteProduct "${testProduct.projectId}" "${
-      testProduct.location
-    }" "${testProduct.productId}"`,
-    cwd
-  );
-
-  try {
-    await productSearch.getProduct({name: `${testProduct.productPath}`});
-    t.fail('Product was not deleted');
-  } catch (err) {
-    t.true(err.message.includes('Not found'));
-  }
+  t.true(output.includes(`response.uri: gs://`));
 });

--- a/samples/productSearch/system-test/referenceImages.v1p3beta1.test.js
+++ b/samples/productSearch/system-test/referenceImages.v1p3beta1.test.js
@@ -28,10 +28,10 @@ const cwd = path.join(__dirname, `..`);
 const testProduct = {
   projectId: process.env.GCLOUD_PROJECT,
   location: 'us-west1',
-  productId: 'test_product_id_1',
-  productDisplayName: 'test_product_display_name_1',
+  productId: 'fake_product_id_for_testing',
+  productDisplayName: 'fake_product_display_name_for_testing',
   productCategory: 'homegoods',
-  productReferenceImageId: 'referenceImageId1234',
+  productReferenceImageId: 'fake_reference_image_id_for_testing',
   productImageUri: 'gs://python-docs-samples-tests/product_search/shoes_1.jpg',
 };
 testProduct.productPath = productSearch.productPath(
@@ -94,6 +94,25 @@ test(`should create reference image`, async t => {
 
   const output = await tools.runAsync(
     `${cmd} createReferenceImage "${testProduct.projectId}" "${
+        testProduct.location}" "${testProduct.productId}" "${
+        testProduct.productReferenceImageId}" "${testProduct.productImageUri}"`,
+    cwd
+  );
+
+  t.true(output.includes(`response.uri: gs://`));
+});
+
+test(`should get reference image`, async t => {
+  var productPath = productSearch.productPath(
+    testProduct.projectId,
+    testProduct.location,
+    testProduct.productId
+  );
+
+  t.falsy(await getProductOrFalse(productPath));
+
+  const output = await tools.runAsync(
+    `${cmd} getReferenceImage "${testProduct.projectId}" "${
         testProduct.location}" "${testProduct.productId}" "${
         testProduct.productReferenceImageId}" "${testProduct.productImageUri}"`,
     cwd

--- a/samples/system-test/products.v1p3beta1.test.js
+++ b/samples/system-test/products.v1p3beta1.test.js
@@ -1,0 +1,129 @@
+/**
+ * Copyright 2018, Google, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const path = require(`path`);
+const uuid = require(`uuid`);
+const vision = require('@google-cloud/vision').v1p3beta1;
+const productSearch = new vision.ProductSearchClient();
+const test = require(`ava`);
+const tools = require(`@google-cloud/nodejs-repo-tools`);
+const cmd = `node productSearch/products.v1p3beta1.js`;
+const cwd = path.join(__dirname, `..`);
+
+// Shared fixture data for product tests
+const testProduct = {
+  projectId: process.env.GCLOUD_PROJECT,
+  location: 'us-west1',
+  productId: 'test_product_id_1',
+  productDisplayName: 'test_product_display_name_1',
+  productCategory: 'homegoods',
+};
+testProduct.productPath = productSearch.productPath(
+  testProduct.projectId, testProduct.location, testProduct.productId
+);
+testProduct.createdProductPaths = [];
+
+// Helper function: returns product if exists else false
+async function getProductOrFalse(productPath) {
+  try {
+    const response = await productSearch.getProduct({name: productPath});
+    return response[0];
+  } catch (err) {
+    if (err.message.includes('Not found')) {
+      return false;
+    } else {
+      throw err;
+    }
+  }
+}
+
+test.before(tools.checkCredentials);
+test.before(async () => {
+  // Create a test product for each test
+  try {
+    await productSearch.createProduct({
+      parent: productSearch.locationPath(
+        testProduct.projectId, testProduct.location
+      ),
+      productId: testProduct.productId,
+      product: {
+        displayName: testProduct.productDisplayName,
+        productCategory: testProduct.productCategory,
+      }
+    });
+    testProduct.createdProductPaths.push(testProduct.productPath);
+  } catch (err) {} // ignore error
+});
+test.after(async () => {
+  // Delete products after each test
+  testProduct.createdProductPaths.forEach(async path => {
+    try {
+      await productSearch.deleteProduct({name: path});
+    } catch (err) {} // ignore error
+  });
+});
+
+test(`should create product`, async t => {
+  var newProductId = `ProductId${uuid.v4()}`;
+  var newProductPath = productSearch.productPath(
+    testProduct.projectId, testProduct.location, newProductId
+  );
+  t.falsy(await getProductOrFalse(newProductPath));
+  testProduct.createdProductPaths.push(newProductPath);
+
+  const output = await tools.runAsync(
+    `${cmd} createProduct "${testProduct.projectId}" "${testProduct.location}" "${newProductId}" "${testProduct.productDisplayName}" "${testProduct.productCategory}"`,
+    cwd
+  );
+
+  t.true(output.includes(`Product name: ${newProductPath}`));
+
+  const newProduct = await getProductOrFalse(newProductPath);
+  t.true(newProduct.displayName == testProduct.productDisplayName);
+  t.true(newProduct.productCategory == testProduct.productCategory);
+});
+
+test(`should list products`, async t => {
+  const output = await tools.runAsync(
+    `${cmd} listProducts "${testProduct.projectId}" "${testProduct.location}"`,
+    cwd
+  );
+
+  t.true(output.includes(`Product name: projects/${testProduct.projectId}/locations/${testProduct.location}/products/${testProduct.productId}`));
+  t.true(output.includes(`Product id: ${testProduct.productId}`));
+  t.true(output.includes(`Product display name: ${testProduct.productDisplayName}`));
+  t.true(output.includes(`Product description:`));
+  t.true(output.includes(`Product category: ${testProduct.productCategory}`));
+  t.true(output.includes(`Product labels:`));
+});
+
+test(`should delete product`, async t => {
+  const product = await productSearch.getProduct({name: `${testProduct.productPath}`});
+  t.truthy(product);
+
+  const output = await tools.runAsync(
+    `${cmd} deleteProduct "${testProduct.projectId}" "${testProduct.location}" "${testProduct.productId}"`,
+    cwd
+  );
+
+  try {
+    await productSearch.getProduct({name: `${testProduct.productPath}`});
+    t.fail('Product was not deleted');
+  } catch (err) {
+    t.true(err.message.includes('Not found'));
+  }
+});

--- a/samples/system-test/products.v1p3beta1.test.js
+++ b/samples/system-test/products.v1p3beta1.test.js
@@ -33,7 +33,9 @@ const testProduct = {
   productCategory: 'homegoods',
 };
 testProduct.productPath = productSearch.productPath(
-  testProduct.projectId, testProduct.location, testProduct.productId
+  testProduct.projectId,
+  testProduct.location,
+  testProduct.productId
 );
 testProduct.createdProductPaths = [];
 
@@ -57,13 +59,14 @@ test.before(async () => {
   try {
     await productSearch.createProduct({
       parent: productSearch.locationPath(
-        testProduct.projectId, testProduct.location
+        testProduct.projectId,
+        testProduct.location
       ),
       productId: testProduct.productId,
       product: {
         displayName: testProduct.productDisplayName,
         productCategory: testProduct.productCategory,
-      }
+      },
     });
     testProduct.createdProductPaths.push(testProduct.productPath);
   } catch (err) {} // ignore error
@@ -80,13 +83,19 @@ test.after(async () => {
 test(`should create product`, async t => {
   var newProductId = `ProductId${uuid.v4()}`;
   var newProductPath = productSearch.productPath(
-    testProduct.projectId, testProduct.location, newProductId
+    testProduct.projectId,
+    testProduct.location,
+    newProductId
   );
   t.falsy(await getProductOrFalse(newProductPath));
   testProduct.createdProductPaths.push(newProductPath);
 
   const output = await tools.runAsync(
-    `${cmd} createProduct "${testProduct.projectId}" "${testProduct.location}" "${newProductId}" "${testProduct.productDisplayName}" "${testProduct.productCategory}"`,
+    `${cmd} createProduct "${testProduct.projectId}" "${
+      testProduct.location
+    }" "${newProductId}" "${testProduct.productDisplayName}" "${
+      testProduct.productCategory
+    }"`,
     cwd
   );
 
@@ -103,20 +112,32 @@ test(`should list products`, async t => {
     cwd
   );
 
-  t.true(output.includes(`Product name: projects/${testProduct.projectId}/locations/${testProduct.location}/products/${testProduct.productId}`));
+  t.true(
+    output.includes(
+      `Product name: projects/${testProduct.projectId}/locations/${
+        testProduct.location
+      }/products/${testProduct.productId}`
+    )
+  );
   t.true(output.includes(`Product id: ${testProduct.productId}`));
-  t.true(output.includes(`Product display name: ${testProduct.productDisplayName}`));
+  t.true(
+    output.includes(`Product display name: ${testProduct.productDisplayName}`)
+  );
   t.true(output.includes(`Product description:`));
   t.true(output.includes(`Product category: ${testProduct.productCategory}`));
   t.true(output.includes(`Product labels:`));
 });
 
 test(`should delete product`, async t => {
-  const product = await productSearch.getProduct({name: `${testProduct.productPath}`});
+  const product = await productSearch.getProduct({
+    name: `${testProduct.productPath}`,
+  });
   t.truthy(product);
 
   const output = await tools.runAsync(
-    `${cmd} deleteProduct "${testProduct.projectId}" "${testProduct.location}" "${testProduct.productId}"`,
+    `${cmd} deleteProduct "${testProduct.projectId}" "${
+      testProduct.location
+    }" "${testProduct.productId}"`,
     cwd
   );
 

--- a/samples/system-test/products.v1p3beta1.test.js
+++ b/samples/system-test/products.v1p3beta1.test.js
@@ -106,6 +106,22 @@ test(`should create product`, async t => {
   t.true(newProduct.productCategory == testProduct.productCategory);
 });
 
+test(`should get product`, async t => {
+  const output = await tools.runAsync(
+    `${cmd} getProduct "${testProduct.projectId}" "${testProduct.location}" "${
+      testProduct.productId
+    }"`,
+    cwd
+  );
+
+  t.true(output.includes(`Product name: ${testProduct.productPath}`));
+  t.true(output.includes(`Product id: ${testProduct.productId}`));
+  t.true(output.includes(`Product display name:`));
+  t.true(output.includes(`Product description:`));
+  t.true(output.includes(`Product category: ${testProduct.productCategory}`));
+  t.true(output.includes(`Product labels:`));
+});
+
 test(`should list products`, async t => {
   const output = await tools.runAsync(
     `${cmd} listProducts "${testProduct.projectId}" "${testProduct.location}"`,


### PR DESCRIPTION
### Product Search (v1p3beta1)

This Pull Request adds the code samples for cloud.google.com documentation for Product Search How-to Guides

Product Search How-to Guides –> [vision/product-search/docs/how-to](https://cloud.google.com/vision/product-search/docs/how-to)

#### `products.js`

 - [x] `create_product`
 - [x] `get_product`
 - [x] `list_products`
 - [x] `delete_product`
 - [x] `update_product_labels`

#### `productSets.js`

 - [x] `create_product_set`
 - [x] `get_product_set`
 - [x] `list_product_sets`
 - [x] `delete_product_set`

##### –> Products in `productSets.js`
 - [x] `add_product_to_product_set`
 - [x] `list_products_in_product_set`
 - [x] `remove_product_from_product_set`

#### `referenceImages.js`
 - [x] `create_reference_image`
 - [x] `get_reference_image`
 - [x] `list_reference_images`
 - [x] `delete_reference_image`

#### `similarProducts.js`
 - [ ] `get_similar_products_file`
 - [ ] `get_similar_products_uri`

For the canonical versions, please see the [Python Product Search Samples](https://github.com/GoogleCloudPlatform/python-docs-samples/tree/master/vision/cloud-client/product_search) in [python-docs-samples](https://github.com/GoogleCloudPlatform/python-docs-samples/)

These samples are in Beta and require using the `v1p3beta1` API endpoint:

```js
const vision = require('@google-cloud/vision').v1p3beta1;
const client = new vision.ProductSearchClient();
```

Before being ready for review & merge:

 - [ ] All samples tested & green
 - [ ] Linter passes (`prettier --write *.js`)
 - [ ] README scaffolded (`npm run generate-scaffolding`)