### PR TITLE
build: add set -x to .sh to show the command being executed

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -eo pipefail
+set -xeo pipefail
 
 cd github/nodejs-vision
 npm install

--- a/.kokoro/docs.sh
+++ b/.kokoro/docs.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -eo pipefail
+set -xeo pipefail
 
 cd github/nodejs-vision
 

--- a/.kokoro/lint.sh
+++ b/.kokoro/lint.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -eo pipefail
+set -xeo pipefail
 
 cd github/nodejs-vision
 

--- a/.kokoro/trampoline.sh
+++ b/.kokoro/trampoline.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -eo pipefail
+set -xeo pipefail
 
 # Always run the cleanup script, regardless of the success of bouncing into
 # the container.


### PR DESCRIPTION
Since we're executing shell scripts, we don't get the same visibility as we do in CircleCI on which command is being executed and which is causing a failure. This will show the command being executed, prepended by a `+` sign:

```
+ npm install
...
```