### PR TITLE
build(kokoro): samples-test.sh need GCLOUD_PROJECT env; node6 and node8 is using wrong .sh

### DIFF
--- a/.kokoro/continuous/node6/common.cfg
+++ b/.kokoro/continuous/node6/common.cfg
@@ -20,5 +20,5 @@ env_vars: {
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/nodejs-vision/.kokoro/build.sh"
+    value: "github/nodejs-vision/.kokoro/test.sh"
 }

--- a/.kokoro/continuous/node8/common.cfg
+++ b/.kokoro/continuous/node8/common.cfg
@@ -20,5 +20,5 @@ env_vars: {
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/nodejs-vision/.kokoro/build.sh"
+    value: "github/nodejs-vision/.kokoro/test.sh"
 }

--- a/.kokoro/samples-test.sh
+++ b/.kokoro/samples-test.sh
@@ -18,6 +18,7 @@ set -xeo pipefail
 
 # Setup service account credentials.
 export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/service-account.json
+export GCLOUD_PROJECT=long-door-651
 
 cd github/nodejs-vision
 


### PR DESCRIPTION
Hope this is one of the last Kokoro PR..