### PR TITLE
Fix response output for Detect Labels

### DIFF
--- a/samples/detect.js
+++ b/samples/detect.js
@@ -102,7 +102,7 @@ function detectLabels(fileName) {
     .then(results => {
       const labels = results[0].labelAnnotations;
       console.log('Labels:');
-      labels.forEach(label => console.log(label));
+      labels.forEach(label => console.log(label.description));
     })
     .catch(err => {
       console.error('ERROR:', err);
@@ -130,7 +130,7 @@ function detectLabelsGCS(bucketName, fileName) {
     .then(results => {
       const labels = results[0].labelAnnotations;
       console.log('Labels:');
-      labels.forEach(label => console.log(label));
+      labels.forEach(label => console.log(label.description));
     })
     .catch(err => {
       console.error('ERROR:', err);


### PR DESCRIPTION
Before, this was dumping an object via console.log.
Now, this properly prints just the label description.

**Before**

```js
$ node detect.js labels resources/duck_and_truck.jpg 

Labels:
{ locations: [],
  properties: [],
  mid: '/m/0138tl',
  locale: '',
  description: 'toy',
  score: 0.9380661845207214,
  confidence: 0,
  topicality: 0.9380661845207214,
  boundingPoly: null }
{ locations: [],
  properties: [],
  mid: '/m/088fh',
  locale: '',
  description: 'yellow',
  score: 0.9219182133674622,
  confidence: 0,
  topicality: 0.9219182133674622,
  boundingPoly: null }
# ...
```

**After**

```js
$ node detect.js labels resources/duck_and_truck.jpg 

Labels:
toy
yellow
product
ducks geese and swans
plastic
water bird
product
```