### PR TITLE
[DO NOT MERGE] Make Product Search tests run

### DIFF
--- a/samples/system-test/importProductSets.v1p3beta1.test.js
+++ b/samples/system-test/importProductSets.v1p3beta1.test.js
@@ -19,7 +19,7 @@ const path = require(`path`);
 const test = require(`ava`);
 const tools = require(`@google-cloud/nodejs-repo-tools`);
 const cmd = `node importProductSets.v1p3beta1.js`;
-const cwd = path.join(__dirname, `..`);
+const cwd = path.join(__dirname, `..`, `productSearch`);
 
 //Shared fixture data for product tests
 const testImportProductSets = {

--- a/samples/system-test/productSearch.v1p3beta1.test.js
+++ b/samples/system-test/productSearch.v1p3beta1.test.js
@@ -21,7 +21,7 @@ const productSearchClient = new vision.ProductSearchClient();
 const test = require(`ava`);
 const tools = require(`@google-cloud/nodejs-repo-tools`);
 const cmd = `node productSearch.v1p3beta1.js`;
-const cwd = path.join(__dirname, `..`);
+const cwd = path.join(__dirname, `..`, `productSearch`);
 
 // Shared fixture data for product tests
 const testProductSet = {

--- a/samples/system-test/productSets.v1p3beta1.test.js
+++ b/samples/system-test/productSets.v1p3beta1.test.js
@@ -22,7 +22,7 @@ const productSearch = new vision.ProductSearchClient();
 const test = require(`ava`);
 const tools = require(`@google-cloud/nodejs-repo-tools`);
 const cmd = `node productSets.v1p3beta1.js`;
-const cwd = path.join(__dirname, `..`);
+const cwd = path.join(__dirname, `..`, `productSearch`);
 
 // Shared fixture data for product tests
 const testProductSet = {

--- a/samples/system-test/products.v1p3beta1.test.js
+++ b/samples/system-test/products.v1p3beta1.test.js
@@ -22,7 +22,7 @@ const productSearch = new vision.ProductSearchClient();
 const test = require(`ava`);
 const tools = require(`@google-cloud/nodejs-repo-tools`);
 const cmd = `node products.v1p3beta1.js`;
-const cwd = path.join(__dirname, `..`);
+const cwd = path.join(__dirname, `..`, `productSearch`);
 
 // Shared fixture data for product tests
 const testProduct = {

--- a/samples/system-test/referenceImages.v1p3beta1.test.js
+++ b/samples/system-test/referenceImages.v1p3beta1.test.js
@@ -22,7 +22,7 @@ const productSearchClient = new vision.ProductSearchClient();
 const test = require(`ava`);
 const tools = require(`@google-cloud/nodejs-repo-tools`);
 const cmd = `node referenceImages.v1p3beta1.js`;
-const cwd = path.join(__dirname, `..`);
+const cwd = path.join(__dirname, `..`, `productSearch`);
 
 // Shared fixture data for product tests
 const testProduct = {

--- a/samples/system-test/similarProducts.v1p3beta1.test.js
+++ b/samples/system-test/similarProducts.v1p3beta1.test.js
@@ -21,7 +21,7 @@ const productSearch = new vision.ProductSearchClient();
 const test = require(`ava`);
 const tools = require(`@google-cloud/nodejs-repo-tools`);
 const cmd = `node similarProducts.v1p3beta1.js`;
-const cwd = path.join(__dirname, `..`);
+const cwd = path.join(__dirname, `..`, `productSearch`);
 const filter = ['', 'style=womens'];
 const localPath = './resources/shoes_1.jpg';
 const gcsUri = 'gs://nodejs-docs-samples/product-search/shoes_1.jpg';


### PR DESCRIPTION
### `mv samples/productSearch/system-test/* samples/system-test/`

Running `npm test` wasn't running these samples (not locally or on CI)

Simply moved them into the primary sample test directory as an easy fix

Unfortunately the tests are failing (see the CI test results on this PR)

I spent a little while trying to get them to work and made a bit of progress, but don't have time to truly resolve them. So creating an issue to track it. And this PR so that the tests can actually be run.

This PR may be deleted without merge. I want to provide it so that the person fixing the tests can use this to immediately see failures with `npm test`

See issue: #266


