### PR TITLE
docs: improve detect.js samples

### DIFF
--- a/samples/detect.js
+++ b/samples/detect.js
@@ -635,7 +635,7 @@ async function detectFulltextGCS(bucketName, fileName) {
   // [END vision_fulltext_detection_gcs]
 }
 
-async function detectPdfText(bucketName, fileName) {
+async function detectPdfText(bucketName, fileName, outputPrefix) {
   // [START vision_text_detection_pdf_gcs]
 
   // Imports the Google Cloud client libraries
@@ -651,9 +651,11 @@ async function detectPdfText(bucketName, fileName) {
   // const bucketName = 'my-bucket';
   // Path to PDF file within bucket
   // const fileName = 'path/to/document.pdf';
+  // The folder to store the results
+  // const outputPrefix = 'results'
 
   const gcsSourceUri = `gs://${bucketName}/${fileName}`;
-  const gcsDestinationUri = `gs://${bucketName}/${fileName}/`;
+  const gcsDestinationUri = `gs://${bucketName}/${outputPrefix}/`;
 
   const inputConfig = {
     // Supported mime_types are: 'application/pdf' and 'image/tiff'
@@ -870,10 +872,10 @@ require(`yargs`) // eslint-disable-line
     opts => detectFulltextGCS(opts.bucketName, opts.fileName)
   )
   .command(
-    `pdf <bucketName> <fileName>`,
+    `pdf <bucketName> <fileName> <outputPrefix>`,
     `Extracts full text from a pdf file`,
     {},
-    opts => detectPdfText(opts.bucketName, opts.fileName)
+    opts => detectPdfText(opts.bucketName, opts.fileName, opts.outputPrefix)
   )
   .command(
     `localize-objects <fileName>`,
@@ -909,7 +911,7 @@ require(`yargs`) // eslint-disable-line
   .example(`node $0 web-geo-gcs my-bucket your-image.jpg`)
   .example(`node $0 fulltext ./resources/wakeupcat.jpg`)
   .example(`node $0 fulltext-gcs my-bucket your-image.jpg`)
-  .example(`node $0 pdf my-bucket my-pdf.pdf`)
+  .example(`node $0 pdf my-bucket my-pdf.pdf results`)
   .example(`node $0 localize-objects ./resources/duck_and_truck.jpg`)
   .example(`node $0 localize-objects-gcs gs://bucket/bucketImage.png`)
   .wrap(120)

--- a/samples/detect.js
+++ b/samples/detect.js
@@ -653,7 +653,7 @@ async function detectPdfText(bucketName, fileName) {
   // const fileName = 'path/to/document.pdf';
 
   const gcsSourceUri = `gs://${bucketName}/${fileName}`;
-  const gcsDestinationUri = `gs://${bucketName}/${fileName}.json`;
+  const gcsDestinationUri = `gs://${bucketName}/${fileName}/`;
 
   const inputConfig = {
     // Supported mime_types are: 'application/pdf' and 'image/tiff'

--- a/samples/system-test/detect.test.js
+++ b/samples/system-test/detect.test.js
@@ -251,10 +251,7 @@ describe(`detect`, () => {
   });
 
   it(`should extract text from pdf file`, async () => {
-    const output = await tools.runAsync(
-      `${cmd} pdf ${bucketName} ${files[7].name} ${prefix}`,
-      cwd
-    );
+    const output = await exec(`${cmd} pdf ${bucketName} ${files[7].name}`);
     assert.ok(output.includes(`${prefix}`));
   });
 

--- a/samples/system-test/detect.test.js
+++ b/samples/system-test/detect.test.js
@@ -252,7 +252,7 @@ describe(`detect`, () => {
 
   it(`should extract text from pdf file`, async () => {
     const output = await exec(`${cmd} pdf ${bucketName} ${files[7].name}`);
-    assert.ok(output.includes(`${prefix}`));
+    assert.match(output, `/${prefix}`);
   });
 
   it(`should detect objects in a local file`, async () => {

--- a/samples/system-test/detect.test.js
+++ b/samples/system-test/detect.test.js
@@ -251,7 +251,9 @@ describe(`detect`, () => {
   });
 
   it(`should extract text from pdf file`, async () => {
-    const output = await exec(`${cmd} pdf ${bucketName} ${files[7].name} ${prefix}`);
+    const output = await exec(
+      `${cmd} pdf ${bucketName} ${files[7].name} ${prefix}`
+    );
     assert.match(output, `/${prefix}/`);
   });
 

--- a/samples/system-test/detect.test.js
+++ b/samples/system-test/detect.test.js
@@ -254,7 +254,7 @@ describe(`detect`, () => {
     const output = await exec(
       `${cmd} pdf ${bucketName} ${files[7].name} ${prefix}`
     );
-    assert.match(output, `/${prefix}/`);
+    assert.match(output, /results/);
   });
 
   it(`should detect objects in a local file`, async () => {

--- a/samples/system-test/detect.test.js
+++ b/samples/system-test/detect.test.js
@@ -251,7 +251,7 @@ describe(`detect`, () => {
 
   it(`should extract text from pdf file`, async () => {
     const output = await exec(`${cmd} pdf ${bucketName} ${files[7].name}`);
-    assert.match(output, /pdf-ocr.pdf.json/);
+    assert.match(output, /pdf-ocr.pdf/);
   });
 
   it(`should detect objects in a local file`, async () => {

--- a/samples/system-test/detect.test.js
+++ b/samples/system-test/detect.test.js
@@ -27,6 +27,7 @@ const client = new vision.ImageAnnotatorClient();
 
 const storage = new Storage();
 const bucketName = `nodejs-docs-samples-test-${uuid.v4()}`;
+const prefix = 'results';
 const cmd = `node detect.js`;
 const files = [
   `face_no_surprise.jpg`,
@@ -250,8 +251,11 @@ describe(`detect`, () => {
   });
 
   it(`should extract text from pdf file`, async () => {
-    const output = await exec(`${cmd} pdf ${bucketName} ${files[7].name}`);
-    assert.match(output, /pdf-ocr.pdf/);
+    const output = await tools.runAsync(
+      `${cmd} pdf ${bucketName} ${files[7].name} ${prefix}`,
+      cwd
+    );
+    assert.ok(output.includes(`${prefix}`));
   });
 
   it(`should detect objects in a local file`, async () => {

--- a/samples/system-test/detect.test.js
+++ b/samples/system-test/detect.test.js
@@ -251,8 +251,8 @@ describe(`detect`, () => {
   });
 
   it(`should extract text from pdf file`, async () => {
-    const output = await exec(`${cmd} pdf ${bucketName} ${files[7].name}`);
-    assert.match(output, `/${prefix}`);
+    const output = await exec(`${cmd} pdf ${bucketName} ${files[7].name} ${prefix}`);
+    assert.match(output, `/${prefix}/`);
   });
 
   it(`should detect objects in a local file`, async () => {


### PR DESCRIPTION
The destination should be a GCS bucket folder, not a filename as the results concatenate a naming system if the file is multiple pages long.

Fixes #<issue_number_goes_here> (it's a good idea to open an issue first for discussion)

- [ ] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
