### PR TITLE
build: patch Windows container, fixing Node 10

### DIFF
--- a/.kokoro/test.bat
+++ b/.kokoro/test.bat
@@ -17,7 +17,15 @@
 cd /d %~dp0
 cd ..
 
-call npm install -g npm@latest || goto :error
+@rem The image we're currently running has a broken version of Node.js enabled
+@rem by nvm (v10.15.3), which has no npm bin. This hack uses the functional
+@rem Node v8.9.1 to install npm@latest, it then uses this version of npm to
+@rem install npm for v10.15.3.
+call nvm use v8.9.1 || goto :error
+call node C:\Users\kbuilder\AppData\Roaming\nvm-ps\versions\v8.9.1\node_modules\npm-bootstrap\bin\npm-cli.js i npm -g || goto :error
+call nvm use v10.15.3 || goto :error
+call node C:\Users\kbuilder\AppData\Roaming\nvm-ps\versions\v8.9.1\node_modules\npm\bin\npm-cli.js i npm -g || goto :error
+
 call npm install || goto :error
 call npm run test || goto :error
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "eslint-plugin-prettier": "^3.0.0",
     "jsdoc-baseline": "git+https://github.com/hegemonic/jsdoc-baseline.git",
     "intelli-espower-loader": "^1.0.1",
-    "jsdoc": "^3.5.5",
+    "jsdoc": "3.5.5",
     "mocha": "^6.0.0",
     "nyc": "^14.0.0",
     "power-assert": "^1.6.0",


### PR DESCRIPTION
temporary patch broken Windows container, such that tests can be run on Node 10