### PR TITLE
feat: make vision helpers work with JSON proto

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,8 @@
   },
   "dependencies": {
     "@google-cloud/promisify": "^1.0.0",
-    "google-gax": "^1.0.0",
-    "is": "^3.2.1",
-    "protobufjs": "^6.8.6"
+    "google-gax": "^1.5.2",
+    "is": "^3.2.1"
   },
   "devDependencies": {
     "@google-cloud/storage": "^3.0.0",

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -18,7 +18,6 @@
 
 const fs = require('fs');
 const is = require('is');
-const path = require('path');
 const {promisify} = require('@google-cloud/promisify');
 const gax = require('google-gax');
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -20,9 +20,12 @@ const fs = require('fs');
 const is = require('is');
 const path = require('path');
 const {promisify} = require('@google-cloud/promisify');
-const protobuf = require('protobufjs');
-
 const gax = require('google-gax');
+
+// We only need to have a Feature enum from the protos, and we want
+// this enum to work for both gRPC and fallback scenarios.
+// It's enough to have the contents of JSON proto for this purpose.
+const jsonProto = require('../protos/protos.json');
 
 /*!
  * Convert non-object request forms into a correctly-formatted object.
@@ -244,16 +247,7 @@ module.exports = apiVersion => {
     });
   });
 
-  let protoFilesRoot = new gax.GoogleProtoFilesRoot();
-  protoFilesRoot = protobuf.loadSync(
-    path.join(
-      __dirname,
-      '..',
-      'protos',
-      `google/cloud/vision/${apiVersion}/image_annotator.proto`
-    ),
-    protoFilesRoot
-  );
+  const protoFilesRoot = gax.protobuf.Root.fromJSON(jsonProto);
   const features = protoFilesRoot.lookup(
     `google.cloud.vision.${apiVersion}.Feature.Type`
   ).values;


### PR DESCRIPTION
Fixes #431 by loading JSON proto instead of using `GoogleProtoFilesRoot` from gax. In helpers, we only need a `Feature` enum, and it's very easy to get it by reading a JSON proto and making a `protobuf.Root` out of it. This code will work both with regular gRPC and in a fallback scenario.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
