### PR TITLE
feat: deferred client initialization

### DIFF
--- a/src/v1/image_annotator_client.ts
+++ b/src/v1/image_annotator_client.ts
@@ -44,9 +44,14 @@ export class ImageAnnotatorClient {
   private _innerApiCalls: {[name: string]: Function};
   private _pathTemplates: {[name: string]: gax.PathTemplate};
   private _terminated = false;
+  private _opts: ClientOptions;
+  private _gaxModule: typeof gax | typeof gax.fallback;
+  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _protos: {};
+  private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
   operationsClient: gax.OperationsClient;
-  imageAnnotatorStub: Promise<{[name: string]: Function}>;
+  imageAnnotatorStub?: Promise<{[name: string]: Function}>;
 
   /**
    * Construct an instance of ImageAnnotatorClient.
@@ -70,8 +75,6 @@ export class ImageAnnotatorClient {
    *     app is running in an environment which supports
    *     {@link https://developers.google.com/identity/protocols/application-default-credentials Application Default Credentials},
    *     your project ID will be detected automatically.
-   * @param {function} [options.promise] - Custom promise module to use instead
-   *     of native Promises.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    */
@@ -101,25 +104,28 @@ export class ImageAnnotatorClient {
     // If we are in browser, we are already using fallback because of the
     // "browser" field in package.json.
     // But if we were explicitly requested to use fallback, let's do it now.
-    const gaxModule = !isBrowser && opts.fallback ? gax.fallback : gax;
+    this._gaxModule = !isBrowser && opts.fallback ? gax.fallback : gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options
     // sent to the client.
     opts.scopes = (this.constructor as typeof ImageAnnotatorClient).scopes;
-    const gaxGrpc = new gaxModule.GrpcClient(opts);
+    this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
+
+    // Save options to use in initialize() method.
+    this._opts = opts;
 
     // Save the auth object to the client, for use by other methods.
-    this.auth = gaxGrpc.auth as gax.GoogleAuth;
+    this.auth = this._gaxGrpc.auth as gax.GoogleAuth;
 
     // Determine the client header string.
-    const clientHeader = [`gax/${gaxModule.version}`, `gapic/${version}`];
+    const clientHeader = [`gax/${this._gaxModule.version}`, `gapic/${version}`];
     if (typeof process !== 'undefined' && 'versions' in process) {
       clientHeader.push(`gl-node/${process.versions.node}`);
     } else {
-      clientHeader.push(`gl-web/${gaxModule.version}`);
+      clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
     if (!opts.fallback) {
-      clientHeader.push(`grpc/${gaxGrpc.grpcVersion}`);
+      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     }
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
@@ -135,7 +141,7 @@ export class ImageAnnotatorClient {
       'protos',
       'protos.json'
     );
-    const protos = gaxGrpc.loadProto(
+    this._protos = this._gaxGrpc.loadProto(
       opts.fallback ? require('../../protos/protos.json') : nodejsProtoPath
     );
 
@@ -143,13 +149,13 @@ export class ImageAnnotatorClient {
     // identifiers to uniquely identify resources within the API.
     // Create useful helper objects for these.
     this._pathTemplates = {
-      productPathTemplate: new gaxModule.PathTemplate(
+      productPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/locations/{location}/products/{product}'
       ),
-      productSetPathTemplate: new gaxModule.PathTemplate(
+      productSetPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/locations/{location}/productSets/{product_set}'
       ),
-      referenceImagePathTemplate: new gaxModule.PathTemplate(
+      referenceImagePathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/locations/{location}/products/{product}/referenceImages/{reference_image}'
       ),
     };
@@ -158,13 +164,15 @@ export class ImageAnnotatorClient {
     // an Operation object that allows for tracking of the operation,
     // rather than holding a request open.
     const protoFilesRoot = opts.fallback
-      ? gaxModule.protobuf.Root.fromJSON(require('../../protos/protos.json'))
-      : gaxModule.protobuf.loadSync(nodejsProtoPath);
+      ? this._gaxModule.protobuf.Root.fromJSON(
+          require('../../protos/protos.json')
+        )
+      : this._gaxModule.protobuf.loadSync(nodejsProtoPath);
 
-    this.operationsClient = gaxModule
+    this.operationsClient = this._gaxModule
       .lro({
         auth: this.auth,
-        grpc: 'grpc' in gaxGrpc ? gaxGrpc.grpc : undefined,
+        grpc: 'grpc' in this._gaxGrpc ? this._gaxGrpc.grpc : undefined,
       })
       .operationsClient(opts);
     const asyncBatchAnnotateImagesResponse = protoFilesRoot.lookup(
@@ -181,7 +189,7 @@ export class ImageAnnotatorClient {
     ) as gax.protobuf.Type;
 
     this._descriptors.longrunning = {
-      asyncBatchAnnotateImages: new gaxModule.LongrunningDescriptor(
+      asyncBatchAnnotateImages: new this._gaxModule.LongrunningDescriptor(
         this.operationsClient,
         asyncBatchAnnotateImagesResponse.decode.bind(
           asyncBatchAnnotateImagesResponse
@@ -190,7 +198,7 @@ export class ImageAnnotatorClient {
           asyncBatchAnnotateImagesMetadata
         )
       ),
-      asyncBatchAnnotateFiles: new gaxModule.LongrunningDescriptor(
+      asyncBatchAnnotateFiles: new this._gaxModule.LongrunningDescriptor(
         this.operationsClient,
         asyncBatchAnnotateFilesResponse.decode.bind(
           asyncBatchAnnotateFilesResponse
@@ -202,7 +210,7 @@ export class ImageAnnotatorClient {
     };
 
     // Put together the default options sent with requests.
-    const defaults = gaxGrpc.constructSettings(
+    this._defaults = this._gaxGrpc.constructSettings(
       'google.cloud.vision.v1.ImageAnnotator',
       gapicConfig as gax.ClientConfig,
       opts.clientConfig || {},
@@ -213,17 +221,35 @@ export class ImageAnnotatorClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this._innerApiCalls = {};
+  }
+
+  /**
+   * Initialize the client.
+   * Performs asynchronous operations (such as authentication) and prepares the client.
+   * This function will be called automatically when any class method is called for the
+   * first time, but if you need to initialize it before calling an actual method,
+   * feel free to call initialize() directly.
+   *
+   * You can await on this method if you want to make sure the client is initialized.
+   *
+   * @returns {Promise} A promise that resolves to an authenticated service stub.
+   */
+  initialize() {
+    // If the client stub promise is already initialized, return immediately.
+    if (this.imageAnnotatorStub) {
+      return this.imageAnnotatorStub;
+    }
 
     // Put together the "service stub" for
     // google.cloud.vision.v1.ImageAnnotator.
-    this.imageAnnotatorStub = gaxGrpc.createStub(
-      opts.fallback
-        ? (protos as protobuf.Root).lookupService(
+    this.imageAnnotatorStub = this._gaxGrpc.createStub(
+      this._opts.fallback
+        ? (this._protos as protobuf.Root).lookupService(
             'google.cloud.vision.v1.ImageAnnotator'
           )
         : // tslint:disable-next-line no-any
-          (protos as any).google.cloud.vision.v1.ImageAnnotator,
-      opts
+          (this._protos as any).google.cloud.vision.v1.ImageAnnotator,
+      this._opts
     ) as Promise<{[method: string]: Function}>;
 
     // Iterate over each of the methods that the service provides
@@ -248,9 +274,9 @@ export class ImageAnnotatorClient {
         }
       );
 
-      const apiCall = gaxModule.createApiCall(
+      const apiCall = this._gaxModule.createApiCall(
         innerCallPromise,
-        defaults[methodName],
+        this._defaults[methodName],
         this._descriptors.page[methodName] ||
           this._descriptors.stream[methodName] ||
           this._descriptors.longrunning[methodName]
@@ -264,6 +290,8 @@ export class ImageAnnotatorClient {
         return apiCall(argument, callOptions, callback);
       };
     }
+
+    return this.imageAnnotatorStub;
   }
 
   /**
@@ -410,6 +438,7 @@ export class ImageAnnotatorClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.batchAnnotateImages(request, options, callback);
   }
   batchAnnotateFiles(
@@ -502,6 +531,7 @@ export class ImageAnnotatorClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.batchAnnotateFiles(request, options, callback);
   }
 
@@ -612,6 +642,7 @@ export class ImageAnnotatorClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.asyncBatchAnnotateImages(
       request,
       options,
@@ -720,6 +751,7 @@ export class ImageAnnotatorClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.asyncBatchAnnotateFiles(
       request,
       options,
@@ -912,8 +944,9 @@ export class ImageAnnotatorClient {
    * The client will no longer be usable and all future behavior is undefined.
    */
   close(): Promise<void> {
+    this.initialize();
     if (!this._terminated) {
-      return this.imageAnnotatorStub.then(stub => {
+      return this.imageAnnotatorStub!.then(stub => {
         this._terminated = true;
         stub.close();
       });

--- a/src/v1/product_search_client.ts
+++ b/src/v1/product_search_client.ts
@@ -39,16 +39,16 @@ const version = require('../../../package.json').version;
  *  Manages Products and ProductSets of reference images for use in product
  *  search. It uses the following resource model:
  *
- *  - The API has a collection of [ProductSet][google.cloud.vision.v1.ProductSet] resources, named
+ *  - The API has a collection of {@link google.cloud.vision.v1.ProductSet|ProductSet} resources, named
  *  `projects/* /locations/* /productSets/*`, which acts as a way to put different
  *  products into groups to limit identification.
  *
  *  In parallel,
  *
- *  - The API has a collection of [Product][google.cloud.vision.v1.Product] resources, named
+ *  - The API has a collection of {@link google.cloud.vision.v1.Product|Product} resources, named
  *    `projects/* /locations/* /products/*`
  *
- *  - Each [Product][google.cloud.vision.v1.Product] has a collection of [ReferenceImage][google.cloud.vision.v1.ReferenceImage] resources, named
+ *  - Each {@link google.cloud.vision.v1.Product|Product} has a collection of {@link google.cloud.vision.v1.ReferenceImage|ReferenceImage} resources, named
  *    `projects/* /locations/* /products/* /referenceImages/*`
  * @class
  * @memberof v1
@@ -58,9 +58,14 @@ export class ProductSearchClient {
   private _innerApiCalls: {[name: string]: Function};
   private _pathTemplates: {[name: string]: gax.PathTemplate};
   private _terminated = false;
+  private _opts: ClientOptions;
+  private _gaxModule: typeof gax | typeof gax.fallback;
+  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _protos: {};
+  private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
   operationsClient: gax.OperationsClient;
-  productSearchStub: Promise<{[name: string]: Function}>;
+  productSearchStub?: Promise<{[name: string]: Function}>;
 
   /**
    * Construct an instance of ProductSearchClient.
@@ -84,8 +89,6 @@ export class ProductSearchClient {
    *     app is running in an environment which supports
    *     {@link https://developers.google.com/identity/protocols/application-default-credentials Application Default Credentials},
    *     your project ID will be detected automatically.
-   * @param {function} [options.promise] - Custom promise module to use instead
-   *     of native Promises.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    */
@@ -115,25 +118,28 @@ export class ProductSearchClient {
     // If we are in browser, we are already using fallback because of the
     // "browser" field in package.json.
     // But if we were explicitly requested to use fallback, let's do it now.
-    const gaxModule = !isBrowser && opts.fallback ? gax.fallback : gax;
+    this._gaxModule = !isBrowser && opts.fallback ? gax.fallback : gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options
     // sent to the client.
     opts.scopes = (this.constructor as typeof ProductSearchClient).scopes;
-    const gaxGrpc = new gaxModule.GrpcClient(opts);
+    this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
+
+    // Save options to use in initialize() method.
+    this._opts = opts;
 
     // Save the auth object to the client, for use by other methods.
-    this.auth = gaxGrpc.auth as gax.GoogleAuth;
+    this.auth = this._gaxGrpc.auth as gax.GoogleAuth;
 
     // Determine the client header string.
-    const clientHeader = [`gax/${gaxModule.version}`, `gapic/${version}`];
+    const clientHeader = [`gax/${this._gaxModule.version}`, `gapic/${version}`];
     if (typeof process !== 'undefined' && 'versions' in process) {
       clientHeader.push(`gl-node/${process.versions.node}`);
     } else {
-      clientHeader.push(`gl-web/${gaxModule.version}`);
+      clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
     if (!opts.fallback) {
-      clientHeader.push(`grpc/${gaxGrpc.grpcVersion}`);
+      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     }
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
@@ -149,7 +155,7 @@ export class ProductSearchClient {
       'protos',
       'protos.json'
     );
-    const protos = gaxGrpc.loadProto(
+    this._protos = this._gaxGrpc.loadProto(
       opts.fallback ? require('../../protos/protos.json') : nodejsProtoPath
     );
 
@@ -157,16 +163,16 @@ export class ProductSearchClient {
     // identifiers to uniquely identify resources within the API.
     // Create useful helper objects for these.
     this._pathTemplates = {
-      locationPathTemplate: new gaxModule.PathTemplate(
+      locationPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/locations/{location}'
       ),
-      productPathTemplate: new gaxModule.PathTemplate(
+      productPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/locations/{location}/products/{product}'
       ),
-      productSetPathTemplate: new gaxModule.PathTemplate(
+      productSetPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/locations/{location}/productSets/{product_set}'
       ),
-      referenceImagePathTemplate: new gaxModule.PathTemplate(
+      referenceImagePathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/locations/{location}/products/{product}/referenceImages/{reference_image}'
       ),
     };
@@ -175,22 +181,22 @@ export class ProductSearchClient {
     // (e.g. 50 results at a time, with tokens to get subsequent
     // pages). Denote the keys used for pagination and results.
     this._descriptors.page = {
-      listProductSets: new gaxModule.PageDescriptor(
+      listProductSets: new this._gaxModule.PageDescriptor(
         'pageToken',
         'nextPageToken',
         'productSets'
       ),
-      listProducts: new gaxModule.PageDescriptor(
+      listProducts: new this._gaxModule.PageDescriptor(
         'pageToken',
         'nextPageToken',
         'products'
       ),
-      listReferenceImages: new gaxModule.PageDescriptor(
+      listReferenceImages: new this._gaxModule.PageDescriptor(
         'pageToken',
         'nextPageToken',
         'referenceImages'
       ),
-      listProductsInProductSet: new gaxModule.PageDescriptor(
+      listProductsInProductSet: new this._gaxModule.PageDescriptor(
         'pageToken',
         'nextPageToken',
         'products'
@@ -201,13 +207,15 @@ export class ProductSearchClient {
     // an Operation object that allows for tracking of the operation,
     // rather than holding a request open.
     const protoFilesRoot = opts.fallback
-      ? gaxModule.protobuf.Root.fromJSON(require('../../protos/protos.json'))
-      : gaxModule.protobuf.loadSync(nodejsProtoPath);
+      ? this._gaxModule.protobuf.Root.fromJSON(
+          require('../../protos/protos.json')
+        )
+      : this._gaxModule.protobuf.loadSync(nodejsProtoPath);
 
-    this.operationsClient = gaxModule
+    this.operationsClient = this._gaxModule
       .lro({
         auth: this.auth,
-        grpc: 'grpc' in gaxGrpc ? gaxGrpc.grpc : undefined,
+        grpc: 'grpc' in this._gaxGrpc ? this._gaxGrpc.grpc : undefined,
       })
       .operationsClient(opts);
     const importProductSetsResponse = protoFilesRoot.lookup(
@@ -224,12 +232,12 @@ export class ProductSearchClient {
     ) as gax.protobuf.Type;
 
     this._descriptors.longrunning = {
-      importProductSets: new gaxModule.LongrunningDescriptor(
+      importProductSets: new this._gaxModule.LongrunningDescriptor(
         this.operationsClient,
         importProductSetsResponse.decode.bind(importProductSetsResponse),
         importProductSetsMetadata.decode.bind(importProductSetsMetadata)
       ),
-      purgeProducts: new gaxModule.LongrunningDescriptor(
+      purgeProducts: new this._gaxModule.LongrunningDescriptor(
         this.operationsClient,
         purgeProductsResponse.decode.bind(purgeProductsResponse),
         purgeProductsMetadata.decode.bind(purgeProductsMetadata)
@@ -237,7 +245,7 @@ export class ProductSearchClient {
     };
 
     // Put together the default options sent with requests.
-    const defaults = gaxGrpc.constructSettings(
+    this._defaults = this._gaxGrpc.constructSettings(
       'google.cloud.vision.v1.ProductSearch',
       gapicConfig as gax.ClientConfig,
       opts.clientConfig || {},
@@ -248,17 +256,35 @@ export class ProductSearchClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this._innerApiCalls = {};
+  }
+
+  /**
+   * Initialize the client.
+   * Performs asynchronous operations (such as authentication) and prepares the client.
+   * This function will be called automatically when any class method is called for the
+   * first time, but if you need to initialize it before calling an actual method,
+   * feel free to call initialize() directly.
+   *
+   * You can await on this method if you want to make sure the client is initialized.
+   *
+   * @returns {Promise} A promise that resolves to an authenticated service stub.
+   */
+  initialize() {
+    // If the client stub promise is already initialized, return immediately.
+    if (this.productSearchStub) {
+      return this.productSearchStub;
+    }
 
     // Put together the "service stub" for
     // google.cloud.vision.v1.ProductSearch.
-    this.productSearchStub = gaxGrpc.createStub(
-      opts.fallback
-        ? (protos as protobuf.Root).lookupService(
+    this.productSearchStub = this._gaxGrpc.createStub(
+      this._opts.fallback
+        ? (this._protos as protobuf.Root).lookupService(
             'google.cloud.vision.v1.ProductSearch'
           )
         : // tslint:disable-next-line no-any
-          (protos as any).google.cloud.vision.v1.ProductSearch,
-      opts
+          (this._protos as any).google.cloud.vision.v1.ProductSearch,
+      this._opts
     ) as Promise<{[method: string]: Function}>;
 
     // Iterate over each of the methods that the service provides
@@ -298,9 +324,9 @@ export class ProductSearchClient {
         }
       );
 
-      const apiCall = gaxModule.createApiCall(
+      const apiCall = this._gaxModule.createApiCall(
         innerCallPromise,
-        defaults[methodName],
+        this._defaults[methodName],
         this._descriptors.page[methodName] ||
           this._descriptors.stream[methodName] ||
           this._descriptors.longrunning[methodName]
@@ -314,6 +340,8 @@ export class ProductSearchClient {
         return apiCall(argument, callOptions, callback);
       };
     }
+
+    return this.productSearchStub;
   }
 
   /**
@@ -453,6 +481,7 @@ export class ProductSearchClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.createProductSet(request, options, callback);
   }
   getProductSet(
@@ -531,6 +560,7 @@ export class ProductSearchClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.getProductSet(request, options, callback);
   }
   updateProductSet(
@@ -567,7 +597,7 @@ export class ProductSearchClient {
    * @param {google.cloud.vision.v1.ProductSet} request.productSet
    *   Required. The ProductSet resource which replaces the one on the server.
    * @param {google.protobuf.FieldMask} request.updateMask
-   *   The [FieldMask][google.protobuf.FieldMask] that specifies which fields to
+   *   The {@link google.protobuf.FieldMask|FieldMask} that specifies which fields to
    *   update.
    *   If update_mask isn't specified, all mutable fields are to be updated.
    *   Valid mask path is `display_name`.
@@ -615,6 +645,7 @@ export class ProductSearchClient {
     ] = gax.routingHeader.fromParams({
       'product_set.name': request.productSet!.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.updateProductSet(request, options, callback);
   }
   deleteProductSet(
@@ -693,6 +724,7 @@ export class ProductSearchClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.deleteProductSet(request, options, callback);
   }
   createProduct(
@@ -781,6 +813,7 @@ export class ProductSearchClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.createProduct(request, options, callback);
   }
   getProduct(
@@ -859,6 +892,7 @@ export class ProductSearchClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.getProduct(request, options, callback);
   }
   updateProduct(
@@ -903,7 +937,7 @@ export class ProductSearchClient {
    *   Required. The Product resource which replaces the one on the server.
    *   product.name is immutable.
    * @param {google.protobuf.FieldMask} request.updateMask
-   *   The [FieldMask][google.protobuf.FieldMask] that specifies which fields
+   *   The {@link google.protobuf.FieldMask|FieldMask} that specifies which fields
    *   to update.
    *   If update_mask isn't specified, all mutable fields are to be updated.
    *   Valid mask paths include `product_labels`, `display_name`, and
@@ -951,6 +985,7 @@ export class ProductSearchClient {
     ] = gax.routingHeader.fromParams({
       'product.name': request.product!.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.updateProduct(request, options, callback);
   }
   deleteProduct(
@@ -1029,6 +1064,7 @@ export class ProductSearchClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.deleteProduct(request, options, callback);
   }
   createReferenceImage(
@@ -1138,6 +1174,7 @@ export class ProductSearchClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.createReferenceImage(request, options, callback);
   }
   deleteReferenceImage(
@@ -1228,6 +1265,7 @@ export class ProductSearchClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.deleteReferenceImage(request, options, callback);
   }
   getReferenceImage(
@@ -1308,6 +1346,7 @@ export class ProductSearchClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.getReferenceImage(request, options, callback);
   }
   addProductToProductSet(
@@ -1403,6 +1442,7 @@ export class ProductSearchClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.addProductToProductSet(
       request,
       options,
@@ -1495,6 +1535,7 @@ export class ProductSearchClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.removeProductFromProductSet(
       request,
       options,
@@ -1531,14 +1572,14 @@ export class ProductSearchClient {
    * Asynchronous API that imports a list of reference images to specified
    * product sets based on a list of image information.
    *
-   * The [google.longrunning.Operation][google.longrunning.Operation] API can be used to keep track of the
+   * The {@link google.longrunning.Operation|google.longrunning.Operation} API can be used to keep track of the
    * progress and results of the request.
    * `Operation.metadata` contains `BatchOperationMetadata`. (progress)
    * `Operation.response` contains `ImportProductSetsResponse`. (results)
    *
    * The input source of this method is a csv file on Google Cloud Storage.
    * For the format of the csv file please see
-   * [ImportProductSetsGcsSource.csv_file_uri][google.cloud.vision.v1.ImportProductSetsGcsSource.csv_file_uri].
+   * {@link google.cloud.vision.v1.ImportProductSetsGcsSource.csv_file_uri|ImportProductSetsGcsSource.csv_file_uri}.
    *
    * @param {Object} request
    *   The request object that will be sent.
@@ -1600,6 +1641,7 @@ export class ProductSearchClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.importProductSets(request, options, callback);
   }
   purgeProducts(
@@ -1649,7 +1691,7 @@ export class ProductSearchClient {
    * ProductSet, you must wait until the PurgeProducts operation has finished
    * for that ProductSet.
    *
-   * The [google.longrunning.Operation][google.longrunning.Operation] API can be used to keep track of the
+   * The {@link google.longrunning.Operation|google.longrunning.Operation} API can be used to keep track of the
    * progress and results of the request.
    * `Operation.metadata` contains `BatchOperationMetadata`. (progress)
    *
@@ -1719,6 +1761,7 @@ export class ProductSearchClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.purgeProducts(request, options, callback);
   }
   listProductSets(
@@ -1813,6 +1856,7 @@ export class ProductSearchClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.listProductSets(request, options, callback);
   }
 
@@ -1858,6 +1902,7 @@ export class ProductSearchClient {
       parent: request.parent || '',
     });
     const callSettings = new gax.CallSettings(options);
+    this.initialize();
     return this._descriptors.page.listProductSets.createStream(
       this._innerApiCalls.listProductSets as gax.GaxCall,
       request,
@@ -1956,6 +2001,7 @@ export class ProductSearchClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.listProducts(request, options, callback);
   }
 
@@ -2002,6 +2048,7 @@ export class ProductSearchClient {
       parent: request.parent || '',
     });
     const callSettings = new gax.CallSettings(options);
+    this.initialize();
     return this._descriptors.page.listProducts.createStream(
       this._innerApiCalls.listProducts as gax.GaxCall,
       request,
@@ -2105,6 +2152,7 @@ export class ProductSearchClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.listReferenceImages(request, options, callback);
   }
 
@@ -2154,6 +2202,7 @@ export class ProductSearchClient {
       parent: request.parent || '',
     });
     const callSettings = new gax.CallSettings(options);
+    this.initialize();
     return this._descriptors.page.listReferenceImages.createStream(
       this._innerApiCalls.listReferenceImages as gax.GaxCall,
       request,
@@ -2254,6 +2303,7 @@ export class ProductSearchClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.listProductsInProductSet(
       request,
       options,
@@ -2304,6 +2354,7 @@ export class ProductSearchClient {
       name: request.name || '',
     });
     const callSettings = new gax.CallSettings(options);
+    this.initialize();
     return this._descriptors.page.listProductsInProductSet.createStream(
       this._innerApiCalls.listProductsInProductSet as gax.GaxCall,
       request,
@@ -2533,8 +2584,9 @@ export class ProductSearchClient {
    * The client will no longer be usable and all future behavior is undefined.
    */
   close(): Promise<void> {
+    this.initialize();
     if (!this._terminated) {
-      return this.productSearchStub.then(stub => {
+      return this.productSearchStub!.then(stub => {
         this._terminated = true;
         stub.close();
       });

--- a/src/v1p1beta1/image_annotator_client.ts
+++ b/src/v1p1beta1/image_annotator_client.ts
@@ -42,8 +42,13 @@ export class ImageAnnotatorClient {
   private _descriptors: Descriptors = {page: {}, stream: {}, longrunning: {}};
   private _innerApiCalls: {[name: string]: Function};
   private _terminated = false;
+  private _opts: ClientOptions;
+  private _gaxModule: typeof gax | typeof gax.fallback;
+  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _protos: {};
+  private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
-  imageAnnotatorStub: Promise<{[name: string]: Function}>;
+  imageAnnotatorStub?: Promise<{[name: string]: Function}>;
 
   /**
    * Construct an instance of ImageAnnotatorClient.
@@ -67,8 +72,6 @@ export class ImageAnnotatorClient {
    *     app is running in an environment which supports
    *     {@link https://developers.google.com/identity/protocols/application-default-credentials Application Default Credentials},
    *     your project ID will be detected automatically.
-   * @param {function} [options.promise] - Custom promise module to use instead
-   *     of native Promises.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    */
@@ -98,25 +101,28 @@ export class ImageAnnotatorClient {
     // If we are in browser, we are already using fallback because of the
     // "browser" field in package.json.
     // But if we were explicitly requested to use fallback, let's do it now.
-    const gaxModule = !isBrowser && opts.fallback ? gax.fallback : gax;
+    this._gaxModule = !isBrowser && opts.fallback ? gax.fallback : gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options
     // sent to the client.
     opts.scopes = (this.constructor as typeof ImageAnnotatorClient).scopes;
-    const gaxGrpc = new gaxModule.GrpcClient(opts);
+    this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
+
+    // Save options to use in initialize() method.
+    this._opts = opts;
 
     // Save the auth object to the client, for use by other methods.
-    this.auth = gaxGrpc.auth as gax.GoogleAuth;
+    this.auth = this._gaxGrpc.auth as gax.GoogleAuth;
 
     // Determine the client header string.
-    const clientHeader = [`gax/${gaxModule.version}`, `gapic/${version}`];
+    const clientHeader = [`gax/${this._gaxModule.version}`, `gapic/${version}`];
     if (typeof process !== 'undefined' && 'versions' in process) {
       clientHeader.push(`gl-node/${process.versions.node}`);
     } else {
-      clientHeader.push(`gl-web/${gaxModule.version}`);
+      clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
     if (!opts.fallback) {
-      clientHeader.push(`grpc/${gaxGrpc.grpcVersion}`);
+      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     }
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
@@ -132,12 +138,12 @@ export class ImageAnnotatorClient {
       'protos',
       'protos.json'
     );
-    const protos = gaxGrpc.loadProto(
+    this._protos = this._gaxGrpc.loadProto(
       opts.fallback ? require('../../protos/protos.json') : nodejsProtoPath
     );
 
     // Put together the default options sent with requests.
-    const defaults = gaxGrpc.constructSettings(
+    this._defaults = this._gaxGrpc.constructSettings(
       'google.cloud.vision.v1p1beta1.ImageAnnotator',
       gapicConfig as gax.ClientConfig,
       opts.clientConfig || {},
@@ -148,17 +154,35 @@ export class ImageAnnotatorClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this._innerApiCalls = {};
+  }
+
+  /**
+   * Initialize the client.
+   * Performs asynchronous operations (such as authentication) and prepares the client.
+   * This function will be called automatically when any class method is called for the
+   * first time, but if you need to initialize it before calling an actual method,
+   * feel free to call initialize() directly.
+   *
+   * You can await on this method if you want to make sure the client is initialized.
+   *
+   * @returns {Promise} A promise that resolves to an authenticated service stub.
+   */
+  initialize() {
+    // If the client stub promise is already initialized, return immediately.
+    if (this.imageAnnotatorStub) {
+      return this.imageAnnotatorStub;
+    }
 
     // Put together the "service stub" for
     // google.cloud.vision.v1p1beta1.ImageAnnotator.
-    this.imageAnnotatorStub = gaxGrpc.createStub(
-      opts.fallback
-        ? (protos as protobuf.Root).lookupService(
+    this.imageAnnotatorStub = this._gaxGrpc.createStub(
+      this._opts.fallback
+        ? (this._protos as protobuf.Root).lookupService(
             'google.cloud.vision.v1p1beta1.ImageAnnotator'
           )
         : // tslint:disable-next-line no-any
-          (protos as any).google.cloud.vision.v1p1beta1.ImageAnnotator,
-      opts
+          (this._protos as any).google.cloud.vision.v1p1beta1.ImageAnnotator,
+      this._opts
     ) as Promise<{[method: string]: Function}>;
 
     // Iterate over each of the methods that the service provides
@@ -178,9 +202,9 @@ export class ImageAnnotatorClient {
         }
       );
 
-      const apiCall = gaxModule.createApiCall(
+      const apiCall = this._gaxModule.createApiCall(
         innerCallPromise,
-        defaults[methodName],
+        this._defaults[methodName],
         this._descriptors.page[methodName] ||
           this._descriptors.stream[methodName] ||
           this._descriptors.longrunning[methodName]
@@ -194,6 +218,8 @@ export class ImageAnnotatorClient {
         return apiCall(argument, callOptions, callback);
       };
     }
+
+    return this.imageAnnotatorStub;
   }
 
   /**
@@ -320,6 +346,7 @@ export class ImageAnnotatorClient {
       options = optionsOrCallback as gax.CallOptions;
     }
     options = options || {};
+    this.initialize();
     return this._innerApiCalls.batchAnnotateImages(request, options, callback);
   }
 
@@ -329,8 +356,9 @@ export class ImageAnnotatorClient {
    * The client will no longer be usable and all future behavior is undefined.
    */
   close(): Promise<void> {
+    this.initialize();
     if (!this._terminated) {
-      return this.imageAnnotatorStub.then(stub => {
+      return this.imageAnnotatorStub!.then(stub => {
         this._terminated = true;
         stub.close();
       });

--- a/src/v1p3beta1/image_annotator_client.ts
+++ b/src/v1p3beta1/image_annotator_client.ts
@@ -44,9 +44,14 @@ export class ImageAnnotatorClient {
   private _innerApiCalls: {[name: string]: Function};
   private _pathTemplates: {[name: string]: gax.PathTemplate};
   private _terminated = false;
+  private _opts: ClientOptions;
+  private _gaxModule: typeof gax | typeof gax.fallback;
+  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _protos: {};
+  private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
   operationsClient: gax.OperationsClient;
-  imageAnnotatorStub: Promise<{[name: string]: Function}>;
+  imageAnnotatorStub?: Promise<{[name: string]: Function}>;
 
   /**
    * Construct an instance of ImageAnnotatorClient.
@@ -70,8 +75,6 @@ export class ImageAnnotatorClient {
    *     app is running in an environment which supports
    *     {@link https://developers.google.com/identity/protocols/application-default-credentials Application Default Credentials},
    *     your project ID will be detected automatically.
-   * @param {function} [options.promise] - Custom promise module to use instead
-   *     of native Promises.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    */
@@ -101,25 +104,28 @@ export class ImageAnnotatorClient {
     // If we are in browser, we are already using fallback because of the
     // "browser" field in package.json.
     // But if we were explicitly requested to use fallback, let's do it now.
-    const gaxModule = !isBrowser && opts.fallback ? gax.fallback : gax;
+    this._gaxModule = !isBrowser && opts.fallback ? gax.fallback : gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options
     // sent to the client.
     opts.scopes = (this.constructor as typeof ImageAnnotatorClient).scopes;
-    const gaxGrpc = new gaxModule.GrpcClient(opts);
+    this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
+
+    // Save options to use in initialize() method.
+    this._opts = opts;
 
     // Save the auth object to the client, for use by other methods.
-    this.auth = gaxGrpc.auth as gax.GoogleAuth;
+    this.auth = this._gaxGrpc.auth as gax.GoogleAuth;
 
     // Determine the client header string.
-    const clientHeader = [`gax/${gaxModule.version}`, `gapic/${version}`];
+    const clientHeader = [`gax/${this._gaxModule.version}`, `gapic/${version}`];
     if (typeof process !== 'undefined' && 'versions' in process) {
       clientHeader.push(`gl-node/${process.versions.node}`);
     } else {
-      clientHeader.push(`gl-web/${gaxModule.version}`);
+      clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
     if (!opts.fallback) {
-      clientHeader.push(`grpc/${gaxGrpc.grpcVersion}`);
+      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     }
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
@@ -135,7 +141,7 @@ export class ImageAnnotatorClient {
       'protos',
       'protos.json'
     );
-    const protos = gaxGrpc.loadProto(
+    this._protos = this._gaxGrpc.loadProto(
       opts.fallback ? require('../../protos/protos.json') : nodejsProtoPath
     );
 
@@ -143,13 +149,13 @@ export class ImageAnnotatorClient {
     // identifiers to uniquely identify resources within the API.
     // Create useful helper objects for these.
     this._pathTemplates = {
-      productPathTemplate: new gaxModule.PathTemplate(
+      productPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/locations/{location}/products/{product}'
       ),
-      productSetPathTemplate: new gaxModule.PathTemplate(
+      productSetPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/locations/{location}/productSets/{product_set}'
       ),
-      referenceImagePathTemplate: new gaxModule.PathTemplate(
+      referenceImagePathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/locations/{location}/products/{product}/referenceImages/{reference_image}'
       ),
     };
@@ -158,13 +164,15 @@ export class ImageAnnotatorClient {
     // an Operation object that allows for tracking of the operation,
     // rather than holding a request open.
     const protoFilesRoot = opts.fallback
-      ? gaxModule.protobuf.Root.fromJSON(require('../../protos/protos.json'))
-      : gaxModule.protobuf.loadSync(nodejsProtoPath);
+      ? this._gaxModule.protobuf.Root.fromJSON(
+          require('../../protos/protos.json')
+        )
+      : this._gaxModule.protobuf.loadSync(nodejsProtoPath);
 
-    this.operationsClient = gaxModule
+    this.operationsClient = this._gaxModule
       .lro({
         auth: this.auth,
-        grpc: 'grpc' in gaxGrpc ? gaxGrpc.grpc : undefined,
+        grpc: 'grpc' in this._gaxGrpc ? this._gaxGrpc.grpc : undefined,
       })
       .operationsClient(opts);
     const asyncBatchAnnotateFilesResponse = protoFilesRoot.lookup(
@@ -175,7 +183,7 @@ export class ImageAnnotatorClient {
     ) as gax.protobuf.Type;
 
     this._descriptors.longrunning = {
-      asyncBatchAnnotateFiles: new gaxModule.LongrunningDescriptor(
+      asyncBatchAnnotateFiles: new this._gaxModule.LongrunningDescriptor(
         this.operationsClient,
         asyncBatchAnnotateFilesResponse.decode.bind(
           asyncBatchAnnotateFilesResponse
@@ -187,7 +195,7 @@ export class ImageAnnotatorClient {
     };
 
     // Put together the default options sent with requests.
-    const defaults = gaxGrpc.constructSettings(
+    this._defaults = this._gaxGrpc.constructSettings(
       'google.cloud.vision.v1p3beta1.ImageAnnotator',
       gapicConfig as gax.ClientConfig,
       opts.clientConfig || {},
@@ -198,17 +206,35 @@ export class ImageAnnotatorClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this._innerApiCalls = {};
+  }
+
+  /**
+   * Initialize the client.
+   * Performs asynchronous operations (such as authentication) and prepares the client.
+   * This function will be called automatically when any class method is called for the
+   * first time, but if you need to initialize it before calling an actual method,
+   * feel free to call initialize() directly.
+   *
+   * You can await on this method if you want to make sure the client is initialized.
+   *
+   * @returns {Promise} A promise that resolves to an authenticated service stub.
+   */
+  initialize() {
+    // If the client stub promise is already initialized, return immediately.
+    if (this.imageAnnotatorStub) {
+      return this.imageAnnotatorStub;
+    }
 
     // Put together the "service stub" for
     // google.cloud.vision.v1p3beta1.ImageAnnotator.
-    this.imageAnnotatorStub = gaxGrpc.createStub(
-      opts.fallback
-        ? (protos as protobuf.Root).lookupService(
+    this.imageAnnotatorStub = this._gaxGrpc.createStub(
+      this._opts.fallback
+        ? (this._protos as protobuf.Root).lookupService(
             'google.cloud.vision.v1p3beta1.ImageAnnotator'
           )
         : // tslint:disable-next-line no-any
-          (protos as any).google.cloud.vision.v1p3beta1.ImageAnnotator,
-      opts
+          (this._protos as any).google.cloud.vision.v1p3beta1.ImageAnnotator,
+      this._opts
     ) as Promise<{[method: string]: Function}>;
 
     // Iterate over each of the methods that the service provides
@@ -231,9 +257,9 @@ export class ImageAnnotatorClient {
         }
       );
 
-      const apiCall = gaxModule.createApiCall(
+      const apiCall = this._gaxModule.createApiCall(
         innerCallPromise,
-        defaults[methodName],
+        this._defaults[methodName],
         this._descriptors.page[methodName] ||
           this._descriptors.stream[methodName] ||
           this._descriptors.longrunning[methodName]
@@ -247,6 +273,8 @@ export class ImageAnnotatorClient {
         return apiCall(argument, callOptions, callback);
       };
     }
+
+    return this.imageAnnotatorStub;
   }
 
   /**
@@ -373,6 +401,7 @@ export class ImageAnnotatorClient {
       options = optionsOrCallback as gax.CallOptions;
     }
     options = options || {};
+    this.initialize();
     return this._innerApiCalls.batchAnnotateImages(request, options, callback);
   }
 
@@ -458,6 +487,7 @@ export class ImageAnnotatorClient {
       options = optionsOrCallback as gax.CallOptions;
     }
     options = options || {};
+    this.initialize();
     return this._innerApiCalls.asyncBatchAnnotateFiles(
       request,
       options,
@@ -650,8 +680,9 @@ export class ImageAnnotatorClient {
    * The client will no longer be usable and all future behavior is undefined.
    */
   close(): Promise<void> {
+    this.initialize();
     if (!this._terminated) {
-      return this.imageAnnotatorStub.then(stub => {
+      return this.imageAnnotatorStub!.then(stub => {
         this._terminated = true;
         stub.close();
       });

--- a/src/v1p4beta1/image_annotator_client.ts
+++ b/src/v1p4beta1/image_annotator_client.ts
@@ -44,9 +44,14 @@ export class ImageAnnotatorClient {
   private _innerApiCalls: {[name: string]: Function};
   private _pathTemplates: {[name: string]: gax.PathTemplate};
   private _terminated = false;
+  private _opts: ClientOptions;
+  private _gaxModule: typeof gax | typeof gax.fallback;
+  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _protos: {};
+  private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
   operationsClient: gax.OperationsClient;
-  imageAnnotatorStub: Promise<{[name: string]: Function}>;
+  imageAnnotatorStub?: Promise<{[name: string]: Function}>;
 
   /**
    * Construct an instance of ImageAnnotatorClient.
@@ -70,8 +75,6 @@ export class ImageAnnotatorClient {
    *     app is running in an environment which supports
    *     {@link https://developers.google.com/identity/protocols/application-default-credentials Application Default Credentials},
    *     your project ID will be detected automatically.
-   * @param {function} [options.promise] - Custom promise module to use instead
-   *     of native Promises.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    */
@@ -101,25 +104,28 @@ export class ImageAnnotatorClient {
     // If we are in browser, we are already using fallback because of the
     // "browser" field in package.json.
     // But if we were explicitly requested to use fallback, let's do it now.
-    const gaxModule = !isBrowser && opts.fallback ? gax.fallback : gax;
+    this._gaxModule = !isBrowser && opts.fallback ? gax.fallback : gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options
     // sent to the client.
     opts.scopes = (this.constructor as typeof ImageAnnotatorClient).scopes;
-    const gaxGrpc = new gaxModule.GrpcClient(opts);
+    this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
+
+    // Save options to use in initialize() method.
+    this._opts = opts;
 
     // Save the auth object to the client, for use by other methods.
-    this.auth = gaxGrpc.auth as gax.GoogleAuth;
+    this.auth = this._gaxGrpc.auth as gax.GoogleAuth;
 
     // Determine the client header string.
-    const clientHeader = [`gax/${gaxModule.version}`, `gapic/${version}`];
+    const clientHeader = [`gax/${this._gaxModule.version}`, `gapic/${version}`];
     if (typeof process !== 'undefined' && 'versions' in process) {
       clientHeader.push(`gl-node/${process.versions.node}`);
     } else {
-      clientHeader.push(`gl-web/${gaxModule.version}`);
+      clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
     if (!opts.fallback) {
-      clientHeader.push(`grpc/${gaxGrpc.grpcVersion}`);
+      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     }
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
@@ -135,7 +141,7 @@ export class ImageAnnotatorClient {
       'protos',
       'protos.json'
     );
-    const protos = gaxGrpc.loadProto(
+    this._protos = this._gaxGrpc.loadProto(
       opts.fallback ? require('../../protos/protos.json') : nodejsProtoPath
     );
 
@@ -143,13 +149,13 @@ export class ImageAnnotatorClient {
     // identifiers to uniquely identify resources within the API.
     // Create useful helper objects for these.
     this._pathTemplates = {
-      productPathTemplate: new gaxModule.PathTemplate(
+      productPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/locations/{location}/products/{product}'
       ),
-      productSetPathTemplate: new gaxModule.PathTemplate(
+      productSetPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/locations/{location}/productSets/{product_set}'
       ),
-      referenceImagePathTemplate: new gaxModule.PathTemplate(
+      referenceImagePathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/locations/{location}/products/{product}/referenceImages/{reference_image}'
       ),
     };
@@ -158,13 +164,15 @@ export class ImageAnnotatorClient {
     // an Operation object that allows for tracking of the operation,
     // rather than holding a request open.
     const protoFilesRoot = opts.fallback
-      ? gaxModule.protobuf.Root.fromJSON(require('../../protos/protos.json'))
-      : gaxModule.protobuf.loadSync(nodejsProtoPath);
+      ? this._gaxModule.protobuf.Root.fromJSON(
+          require('../../protos/protos.json')
+        )
+      : this._gaxModule.protobuf.loadSync(nodejsProtoPath);
 
-    this.operationsClient = gaxModule
+    this.operationsClient = this._gaxModule
       .lro({
         auth: this.auth,
-        grpc: 'grpc' in gaxGrpc ? gaxGrpc.grpc : undefined,
+        grpc: 'grpc' in this._gaxGrpc ? this._gaxGrpc.grpc : undefined,
       })
       .operationsClient(opts);
     const asyncBatchAnnotateImagesResponse = protoFilesRoot.lookup(
@@ -181,7 +189,7 @@ export class ImageAnnotatorClient {
     ) as gax.protobuf.Type;
 
     this._descriptors.longrunning = {
-      asyncBatchAnnotateImages: new gaxModule.LongrunningDescriptor(
+      asyncBatchAnnotateImages: new this._gaxModule.LongrunningDescriptor(
         this.operationsClient,
         asyncBatchAnnotateImagesResponse.decode.bind(
           asyncBatchAnnotateImagesResponse
@@ -190,7 +198,7 @@ export class ImageAnnotatorClient {
           asyncBatchAnnotateImagesMetadata
         )
       ),
-      asyncBatchAnnotateFiles: new gaxModule.LongrunningDescriptor(
+      asyncBatchAnnotateFiles: new this._gaxModule.LongrunningDescriptor(
         this.operationsClient,
         asyncBatchAnnotateFilesResponse.decode.bind(
           asyncBatchAnnotateFilesResponse
@@ -202,7 +210,7 @@ export class ImageAnnotatorClient {
     };
 
     // Put together the default options sent with requests.
-    const defaults = gaxGrpc.constructSettings(
+    this._defaults = this._gaxGrpc.constructSettings(
       'google.cloud.vision.v1p4beta1.ImageAnnotator',
       gapicConfig as gax.ClientConfig,
       opts.clientConfig || {},
@@ -213,17 +221,35 @@ export class ImageAnnotatorClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this._innerApiCalls = {};
+  }
+
+  /**
+   * Initialize the client.
+   * Performs asynchronous operations (such as authentication) and prepares the client.
+   * This function will be called automatically when any class method is called for the
+   * first time, but if you need to initialize it before calling an actual method,
+   * feel free to call initialize() directly.
+   *
+   * You can await on this method if you want to make sure the client is initialized.
+   *
+   * @returns {Promise} A promise that resolves to an authenticated service stub.
+   */
+  initialize() {
+    // If the client stub promise is already initialized, return immediately.
+    if (this.imageAnnotatorStub) {
+      return this.imageAnnotatorStub;
+    }
 
     // Put together the "service stub" for
     // google.cloud.vision.v1p4beta1.ImageAnnotator.
-    this.imageAnnotatorStub = gaxGrpc.createStub(
-      opts.fallback
-        ? (protos as protobuf.Root).lookupService(
+    this.imageAnnotatorStub = this._gaxGrpc.createStub(
+      this._opts.fallback
+        ? (this._protos as protobuf.Root).lookupService(
             'google.cloud.vision.v1p4beta1.ImageAnnotator'
           )
         : // tslint:disable-next-line no-any
-          (protos as any).google.cloud.vision.v1p4beta1.ImageAnnotator,
-      opts
+          (this._protos as any).google.cloud.vision.v1p4beta1.ImageAnnotator,
+      this._opts
     ) as Promise<{[method: string]: Function}>;
 
     // Iterate over each of the methods that the service provides
@@ -248,9 +274,9 @@ export class ImageAnnotatorClient {
         }
       );
 
-      const apiCall = gaxModule.createApiCall(
+      const apiCall = this._gaxModule.createApiCall(
         innerCallPromise,
-        defaults[methodName],
+        this._defaults[methodName],
         this._descriptors.page[methodName] ||
           this._descriptors.stream[methodName] ||
           this._descriptors.longrunning[methodName]
@@ -264,6 +290,8 @@ export class ImageAnnotatorClient {
         return apiCall(argument, callOptions, callback);
       };
     }
+
+    return this.imageAnnotatorStub;
   }
 
   /**
@@ -390,6 +418,7 @@ export class ImageAnnotatorClient {
       options = optionsOrCallback as gax.CallOptions;
     }
     options = options || {};
+    this.initialize();
     return this._innerApiCalls.batchAnnotateImages(request, options, callback);
   }
   batchAnnotateFiles(
@@ -470,6 +499,7 @@ export class ImageAnnotatorClient {
       options = optionsOrCallback as gax.CallOptions;
     }
     options = options || {};
+    this.initialize();
     return this._innerApiCalls.batchAnnotateFiles(request, options, callback);
   }
 
@@ -560,6 +590,7 @@ export class ImageAnnotatorClient {
       options = optionsOrCallback as gax.CallOptions;
     }
     options = options || {};
+    this.initialize();
     return this._innerApiCalls.asyncBatchAnnotateImages(
       request,
       options,
@@ -648,6 +679,7 @@ export class ImageAnnotatorClient {
       options = optionsOrCallback as gax.CallOptions;
     }
     options = options || {};
+    this.initialize();
     return this._innerApiCalls.asyncBatchAnnotateFiles(
       request,
       options,
@@ -840,8 +872,9 @@ export class ImageAnnotatorClient {
    * The client will no longer be usable and all future behavior is undefined.
    */
   close(): Promise<void> {
+    this.initialize();
     if (!this._terminated) {
-      return this.imageAnnotatorStub.then(stub => {
+      return this.imageAnnotatorStub!.then(stub => {
         this._terminated = true;
         stub.close();
       });

--- a/synth.metadata
+++ b/synth.metadata
@@ -1,12 +1,13 @@
 {
-  "updateTime": "2020-03-02T23:51:22.269713Z",
+  "updateTime": "2020-03-05T23:19:41.489100Z",
   "sources": [
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "244ab2b83a82076a1fa7be63b7e0671af73f5c02",
-        "internalRef": "298455048"
+        "sha": "f0b581b5bdf803e45201ecdb3688b60e381628a8",
+        "internalRef": "299181282",
+        "log": "f0b581b5bdf803e45201ecdb3688b60e381628a8\nfix: recommendationengine/v1beta1 update some comments\n\nPiperOrigin-RevId: 299181282\n\n10e9a0a833dc85ff8f05b2c67ebe5ac785fe04ff\nbuild: add generated BUILD file for Routes Preferred API\n\nPiperOrigin-RevId: 299164808\n\n86738c956a8238d7c77f729be78b0ed887a6c913\npublish v1p1beta1: update with absolute address in comments\n\nPiperOrigin-RevId: 299152383\n\n73d9f2ad4591de45c2e1f352bc99d70cbd2a6d95\npublish v1: update with absolute address in comments\n\nPiperOrigin-RevId: 299147194\n\nd2158f24cb77b0b0ccfe68af784c6a628705e3c6\npublish v1beta2: update with absolute address in comments\n\nPiperOrigin-RevId: 299147086\n\n7fca61292c11b4cd5b352cee1a50bf88819dd63b\npublish v1p2beta1: update with absolute address in comments\n\nPiperOrigin-RevId: 299146903\n\n583b7321624736e2c490e328f4b1957335779295\npublish v1p3beta1: update with absolute address in comments\n\nPiperOrigin-RevId: 299146674\n\n638253bf86d1ce1c314108a089b7351440c2f0bf\nfix: add java_multiple_files option for automl text_sentiment.proto\n\nPiperOrigin-RevId: 298971070\n\n373d655703bf914fb8b0b1cc4071d772bac0e0d1\nUpdate Recs AI Beta public bazel file\n\nPiperOrigin-RevId: 298961623\n\ndcc5d00fc8a8d8b56f16194d7c682027b2c66a3b\nfix: add java_multiple_files option for automl classification.proto\n\nPiperOrigin-RevId: 298953301\n\na3f791827266f3496a6a5201d58adc4bb265c2a3\nchore: automl/v1 publish annotations and retry config\n\nPiperOrigin-RevId: 298942178\n\n01c681586d8d6dbd60155289b587aee678530bd9\nMark return_immediately in PullRequest deprecated.\n\nPiperOrigin-RevId: 298893281\n\nc9f5e9c4bfed54bbd09227e990e7bded5f90f31c\nRemove out of date documentation for predicate support on the Storage API\n\nPiperOrigin-RevId: 298883309\n\nfd5b3b8238d783b04692a113ffe07c0363f5de0f\ngenerate webrisk v1 proto\n\nPiperOrigin-RevId: 298847934\n\n541b1ded4abadcc38e8178680b0677f65594ea6f\nUpdate cloud asset api v1p4beta1.\n\nPiperOrigin-RevId: 298686266\n\nc0d171acecb4f5b0bfd2c4ca34fc54716574e300\n  Updated to include the Notification v1 API.\n\nPiperOrigin-RevId: 298652775\n\n2346a9186c0bff2c9cc439f2459d558068637e05\nAdd Service Directory v1beta1 protos and configs\n\nPiperOrigin-RevId: 298625638\n\na78ed801b82a5c6d9c5368e24b1412212e541bb7\nPublishing v3 protos and configs.\n\nPiperOrigin-RevId: 298607357\n\n4a180bfff8a21645b3a935c2756e8d6ab18a74e0\nautoml/v1beta1 publish proto updates\n\nPiperOrigin-RevId: 298484782\n\n6de6e938b7df1cd62396563a067334abeedb9676\nchore: use the latest gapic-generator and protoc-java-resource-name-plugin in Bazel workspace.\n\nPiperOrigin-RevId: 298474513\n\n"
       }
     },
     {

--- a/test/gapic-image_annotator-v1.ts
+++ b/test/gapic-image_annotator-v1.ts
@@ -104,12 +104,30 @@ describe('v1.ImageAnnotatorClient', () => {
     });
     assert(client);
   });
+  it('has initialize method and supports deferred initialization', async () => {
+    const client = new imageannotatorModule.v1.ImageAnnotatorClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    assert.strictEqual(client.imageAnnotatorStub, undefined);
+    await client.initialize();
+    assert(client.imageAnnotatorStub);
+  });
+  it('has close method', () => {
+    const client = new imageannotatorModule.v1.ImageAnnotatorClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    client.close();
+  });
   describe('batchAnnotateImages', () => {
     it('invokes batchAnnotateImages without error', done => {
       const client = new imageannotatorModule.v1.ImageAnnotatorClient({
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IBatchAnnotateImagesRequest = {};
       request.parent = '';
@@ -133,6 +151,8 @@ describe('v1.ImageAnnotatorClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IBatchAnnotateImagesRequest = {};
       request.parent = '';
@@ -158,6 +178,8 @@ describe('v1.ImageAnnotatorClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IBatchAnnotateFilesRequest = {};
       request.parent = '';
@@ -181,6 +203,8 @@ describe('v1.ImageAnnotatorClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IBatchAnnotateFilesRequest = {};
       request.parent = '';
@@ -206,6 +230,8 @@ describe('v1.ImageAnnotatorClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IAsyncBatchAnnotateImagesRequest = {};
       request.parent = '';
@@ -236,6 +262,8 @@ describe('v1.ImageAnnotatorClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IAsyncBatchAnnotateImagesRequest = {};
       request.parent = '';
@@ -269,6 +297,8 @@ describe('v1.ImageAnnotatorClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IAsyncBatchAnnotateFilesRequest = {};
       request.parent = '';
@@ -299,6 +329,8 @@ describe('v1.ImageAnnotatorClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IAsyncBatchAnnotateFilesRequest = {};
       request.parent = '';

--- a/test/gapic-image_annotator-v1p1beta1.ts
+++ b/test/gapic-image_annotator-v1p1beta1.ts
@@ -83,12 +83,30 @@ describe('v1p1beta1.ImageAnnotatorClient', () => {
     });
     assert(client);
   });
+  it('has initialize method and supports deferred initialization', async () => {
+    const client = new imageannotatorModule.v1p1beta1.ImageAnnotatorClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    assert.strictEqual(client.imageAnnotatorStub, undefined);
+    await client.initialize();
+    assert(client.imageAnnotatorStub);
+  });
+  it('has close method', () => {
+    const client = new imageannotatorModule.v1p1beta1.ImageAnnotatorClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    client.close();
+  });
   describe('batchAnnotateImages', () => {
     it('invokes batchAnnotateImages without error', done => {
       const client = new imageannotatorModule.v1p1beta1.ImageAnnotatorClient({
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p1beta1.IBatchAnnotateImagesRequest = {};
       // Mock response
@@ -111,6 +129,8 @@ describe('v1p1beta1.ImageAnnotatorClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p1beta1.IBatchAnnotateImagesRequest = {};
       // Mock response

--- a/test/gapic-image_annotator-v1p2beta1.ts
+++ b/test/gapic-image_annotator-v1p2beta1.ts
@@ -104,12 +104,30 @@ describe('v1p2beta1.ImageAnnotatorClient', () => {
     });
     assert(client);
   });
+  it('has initialize method and supports deferred initialization', async () => {
+    const client = new imageannotatorModule.v1p2beta1.ImageAnnotatorClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    assert.strictEqual(client.imageAnnotatorStub, undefined);
+    await client.initialize();
+    assert(client.imageAnnotatorStub);
+  });
+  it('has close method', () => {
+    const client = new imageannotatorModule.v1p2beta1.ImageAnnotatorClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    client.close();
+  });
   describe('batchAnnotateImages', () => {
     it('invokes batchAnnotateImages without error', done => {
       const client = new imageannotatorModule.v1p2beta1.ImageAnnotatorClient({
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p2beta1.IBatchAnnotateImagesRequest = {};
       // Mock response
@@ -132,6 +150,8 @@ describe('v1p2beta1.ImageAnnotatorClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p2beta1.IBatchAnnotateImagesRequest = {};
       // Mock response
@@ -156,6 +176,8 @@ describe('v1p2beta1.ImageAnnotatorClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p2beta1.IAsyncBatchAnnotateFilesRequest = {};
       // Mock response
@@ -185,6 +207,8 @@ describe('v1p2beta1.ImageAnnotatorClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p2beta1.IAsyncBatchAnnotateFilesRequest = {};
       // Mock response

--- a/test/gapic-image_annotator-v1p3beta1.ts
+++ b/test/gapic-image_annotator-v1p3beta1.ts
@@ -104,12 +104,30 @@ describe('v1p3beta1.ImageAnnotatorClient', () => {
     });
     assert(client);
   });
+  it('has initialize method and supports deferred initialization', async () => {
+    const client = new imageannotatorModule.v1p3beta1.ImageAnnotatorClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    assert.strictEqual(client.imageAnnotatorStub, undefined);
+    await client.initialize();
+    assert(client.imageAnnotatorStub);
+  });
+  it('has close method', () => {
+    const client = new imageannotatorModule.v1p3beta1.ImageAnnotatorClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    client.close();
+  });
   describe('batchAnnotateImages', () => {
     it('invokes batchAnnotateImages without error', done => {
       const client = new imageannotatorModule.v1p3beta1.ImageAnnotatorClient({
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.IBatchAnnotateImagesRequest = {};
       // Mock response
@@ -132,6 +150,8 @@ describe('v1p3beta1.ImageAnnotatorClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.IBatchAnnotateImagesRequest = {};
       // Mock response
@@ -156,6 +176,8 @@ describe('v1p3beta1.ImageAnnotatorClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.IAsyncBatchAnnotateFilesRequest = {};
       // Mock response
@@ -185,6 +207,8 @@ describe('v1p3beta1.ImageAnnotatorClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.IAsyncBatchAnnotateFilesRequest = {};
       // Mock response

--- a/test/gapic-image_annotator-v1p4beta1.ts
+++ b/test/gapic-image_annotator-v1p4beta1.ts
@@ -104,12 +104,30 @@ describe('v1p4beta1.ImageAnnotatorClient', () => {
     });
     assert(client);
   });
+  it('has initialize method and supports deferred initialization', async () => {
+    const client = new imageannotatorModule.v1p4beta1.ImageAnnotatorClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    assert.strictEqual(client.imageAnnotatorStub, undefined);
+    await client.initialize();
+    assert(client.imageAnnotatorStub);
+  });
+  it('has close method', () => {
+    const client = new imageannotatorModule.v1p4beta1.ImageAnnotatorClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    client.close();
+  });
   describe('batchAnnotateImages', () => {
     it('invokes batchAnnotateImages without error', done => {
       const client = new imageannotatorModule.v1p4beta1.ImageAnnotatorClient({
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IBatchAnnotateImagesRequest = {};
       // Mock response
@@ -132,6 +150,8 @@ describe('v1p4beta1.ImageAnnotatorClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IBatchAnnotateImagesRequest = {};
       // Mock response
@@ -156,6 +176,8 @@ describe('v1p4beta1.ImageAnnotatorClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IBatchAnnotateFilesRequest = {};
       // Mock response
@@ -178,6 +200,8 @@ describe('v1p4beta1.ImageAnnotatorClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IBatchAnnotateFilesRequest = {};
       // Mock response
@@ -202,6 +226,8 @@ describe('v1p4beta1.ImageAnnotatorClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IAsyncBatchAnnotateImagesRequest = {};
       // Mock response
@@ -231,6 +257,8 @@ describe('v1p4beta1.ImageAnnotatorClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IAsyncBatchAnnotateImagesRequest = {};
       // Mock response
@@ -263,6 +291,8 @@ describe('v1p4beta1.ImageAnnotatorClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IAsyncBatchAnnotateFilesRequest = {};
       // Mock response
@@ -292,6 +322,8 @@ describe('v1p4beta1.ImageAnnotatorClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IAsyncBatchAnnotateFilesRequest = {};
       // Mock response

--- a/test/gapic-product_search-v1.ts
+++ b/test/gapic-product_search-v1.ts
@@ -102,12 +102,30 @@ describe('v1.ProductSearchClient', () => {
     });
     assert(client);
   });
+  it('has initialize method and supports deferred initialization', async () => {
+    const client = new productsearchModule.v1.ProductSearchClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    assert.strictEqual(client.productSearchStub, undefined);
+    await client.initialize();
+    assert(client.productSearchStub);
+  });
+  it('has close method', () => {
+    const client = new productsearchModule.v1.ProductSearchClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    client.close();
+  });
   describe('createProductSet', () => {
     it('invokes createProductSet without error', done => {
       const client = new productsearchModule.v1.ProductSearchClient({
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.ICreateProductSetRequest = {};
       request.parent = '';
@@ -131,6 +149,8 @@ describe('v1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.ICreateProductSetRequest = {};
       request.parent = '';
@@ -156,6 +176,8 @@ describe('v1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IGetProductSetRequest = {};
       request.name = '';
@@ -179,6 +201,8 @@ describe('v1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IGetProductSetRequest = {};
       request.name = '';
@@ -204,6 +228,8 @@ describe('v1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IUpdateProductSetRequest = {};
       request.productSet = {};
@@ -228,6 +254,8 @@ describe('v1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IUpdateProductSetRequest = {};
       request.productSet = {};
@@ -254,6 +282,8 @@ describe('v1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IDeleteProductSetRequest = {};
       request.name = '';
@@ -277,6 +307,8 @@ describe('v1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IDeleteProductSetRequest = {};
       request.name = '';
@@ -302,6 +334,8 @@ describe('v1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.ICreateProductRequest = {};
       request.parent = '';
@@ -325,6 +359,8 @@ describe('v1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.ICreateProductRequest = {};
       request.parent = '';
@@ -350,6 +386,8 @@ describe('v1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IGetProductRequest = {};
       request.name = '';
@@ -373,6 +411,8 @@ describe('v1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IGetProductRequest = {};
       request.name = '';
@@ -398,6 +438,8 @@ describe('v1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IUpdateProductRequest = {};
       request.product = {};
@@ -422,6 +464,8 @@ describe('v1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IUpdateProductRequest = {};
       request.product = {};
@@ -448,6 +492,8 @@ describe('v1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IDeleteProductRequest = {};
       request.name = '';
@@ -471,6 +517,8 @@ describe('v1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IDeleteProductRequest = {};
       request.name = '';
@@ -496,6 +544,8 @@ describe('v1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.ICreateReferenceImageRequest = {};
       request.parent = '';
@@ -519,6 +569,8 @@ describe('v1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.ICreateReferenceImageRequest = {};
       request.parent = '';
@@ -544,6 +596,8 @@ describe('v1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IDeleteReferenceImageRequest = {};
       request.name = '';
@@ -567,6 +621,8 @@ describe('v1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IDeleteReferenceImageRequest = {};
       request.name = '';
@@ -592,6 +648,8 @@ describe('v1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IGetReferenceImageRequest = {};
       request.name = '';
@@ -615,6 +673,8 @@ describe('v1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IGetReferenceImageRequest = {};
       request.name = '';
@@ -640,6 +700,8 @@ describe('v1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IAddProductToProductSetRequest = {};
       request.name = '';
@@ -663,6 +725,8 @@ describe('v1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IAddProductToProductSetRequest = {};
       request.name = '';
@@ -688,6 +752,8 @@ describe('v1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IRemoveProductFromProductSetRequest = {};
       request.name = '';
@@ -711,6 +777,8 @@ describe('v1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IRemoveProductFromProductSetRequest = {};
       request.name = '';
@@ -739,6 +807,8 @@ describe('v1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IImportProductSetsRequest = {};
       request.parent = '';
@@ -769,6 +839,8 @@ describe('v1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IImportProductSetsRequest = {};
       request.parent = '';
@@ -802,6 +874,8 @@ describe('v1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IPurgeProductsRequest = {};
       request.parent = '';
@@ -832,6 +906,8 @@ describe('v1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IPurgeProductsRequest = {};
       request.parent = '';
@@ -865,6 +941,8 @@ describe('v1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IListProductSetsRequest = {};
       request.parent = '';
@@ -892,6 +970,8 @@ describe('v1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IListProductSetsRequest = {};
       request.parent = '';
@@ -924,6 +1004,8 @@ describe('v1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IListProductsRequest = {};
       request.parent = '';
@@ -951,6 +1033,8 @@ describe('v1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IListProductsRequest = {};
       request.parent = '';
@@ -983,6 +1067,8 @@ describe('v1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IListReferenceImagesRequest = {};
       request.parent = '';
@@ -1010,6 +1096,8 @@ describe('v1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IListReferenceImagesRequest = {};
       request.parent = '';
@@ -1042,6 +1130,8 @@ describe('v1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IListProductsInProductSetRequest = {};
       request.name = '';
@@ -1072,6 +1162,8 @@ describe('v1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1.IListProductsInProductSetRequest = {};
       request.name = '';

--- a/test/gapic-product_search-v1p3beta1.ts
+++ b/test/gapic-product_search-v1p3beta1.ts
@@ -104,12 +104,30 @@ describe('v1p3beta1.ProductSearchClient', () => {
     });
     assert(client);
   });
+  it('has initialize method and supports deferred initialization', async () => {
+    const client = new productsearchModule.v1p3beta1.ProductSearchClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    assert.strictEqual(client.productSearchStub, undefined);
+    await client.initialize();
+    assert(client.productSearchStub);
+  });
+  it('has close method', () => {
+    const client = new productsearchModule.v1p3beta1.ProductSearchClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    client.close();
+  });
   describe('createProductSet', () => {
     it('invokes createProductSet without error', done => {
       const client = new productsearchModule.v1p3beta1.ProductSearchClient({
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.ICreateProductSetRequest = {};
       request.parent = '';
@@ -133,6 +151,8 @@ describe('v1p3beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.ICreateProductSetRequest = {};
       request.parent = '';
@@ -158,6 +178,8 @@ describe('v1p3beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.IGetProductSetRequest = {};
       request.name = '';
@@ -181,6 +203,8 @@ describe('v1p3beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.IGetProductSetRequest = {};
       request.name = '';
@@ -206,6 +230,8 @@ describe('v1p3beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.IUpdateProductSetRequest = {};
       request.productSet = {};
@@ -230,6 +256,8 @@ describe('v1p3beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.IUpdateProductSetRequest = {};
       request.productSet = {};
@@ -256,6 +284,8 @@ describe('v1p3beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.IDeleteProductSetRequest = {};
       request.name = '';
@@ -279,6 +309,8 @@ describe('v1p3beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.IDeleteProductSetRequest = {};
       request.name = '';
@@ -304,6 +336,8 @@ describe('v1p3beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.ICreateProductRequest = {};
       request.parent = '';
@@ -327,6 +361,8 @@ describe('v1p3beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.ICreateProductRequest = {};
       request.parent = '';
@@ -352,6 +388,8 @@ describe('v1p3beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.IGetProductRequest = {};
       request.name = '';
@@ -375,6 +413,8 @@ describe('v1p3beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.IGetProductRequest = {};
       request.name = '';
@@ -400,6 +440,8 @@ describe('v1p3beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.IUpdateProductRequest = {};
       request.product = {};
@@ -424,6 +466,8 @@ describe('v1p3beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.IUpdateProductRequest = {};
       request.product = {};
@@ -450,6 +494,8 @@ describe('v1p3beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.IDeleteProductRequest = {};
       request.name = '';
@@ -473,6 +519,8 @@ describe('v1p3beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.IDeleteProductRequest = {};
       request.name = '';
@@ -498,6 +546,8 @@ describe('v1p3beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.ICreateReferenceImageRequest = {};
       request.parent = '';
@@ -521,6 +571,8 @@ describe('v1p3beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.ICreateReferenceImageRequest = {};
       request.parent = '';
@@ -546,6 +598,8 @@ describe('v1p3beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.IDeleteReferenceImageRequest = {};
       request.name = '';
@@ -569,6 +623,8 @@ describe('v1p3beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.IDeleteReferenceImageRequest = {};
       request.name = '';
@@ -594,6 +650,8 @@ describe('v1p3beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.IGetReferenceImageRequest = {};
       request.name = '';
@@ -617,6 +675,8 @@ describe('v1p3beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.IGetReferenceImageRequest = {};
       request.name = '';
@@ -642,6 +702,8 @@ describe('v1p3beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.IAddProductToProductSetRequest = {};
       request.name = '';
@@ -665,6 +727,8 @@ describe('v1p3beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.IAddProductToProductSetRequest = {};
       request.name = '';
@@ -690,6 +754,8 @@ describe('v1p3beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.IRemoveProductFromProductSetRequest = {};
       request.name = '';
@@ -713,6 +779,8 @@ describe('v1p3beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.IRemoveProductFromProductSetRequest = {};
       request.name = '';
@@ -741,6 +809,8 @@ describe('v1p3beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.IImportProductSetsRequest = {};
       request.parent = '';
@@ -771,6 +841,8 @@ describe('v1p3beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.IImportProductSetsRequest = {};
       request.parent = '';
@@ -804,6 +876,8 @@ describe('v1p3beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.IListProductSetsRequest = {};
       request.parent = '';
@@ -831,6 +905,8 @@ describe('v1p3beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.IListProductSetsRequest = {};
       request.parent = '';
@@ -863,6 +939,8 @@ describe('v1p3beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.IListProductsRequest = {};
       request.parent = '';
@@ -890,6 +968,8 @@ describe('v1p3beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.IListProductsRequest = {};
       request.parent = '';
@@ -922,6 +1002,8 @@ describe('v1p3beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.IListReferenceImagesRequest = {};
       request.parent = '';
@@ -949,6 +1031,8 @@ describe('v1p3beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.IListReferenceImagesRequest = {};
       request.parent = '';
@@ -981,6 +1065,8 @@ describe('v1p3beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.IListProductsInProductSetRequest = {};
       request.name = '';
@@ -1011,6 +1097,8 @@ describe('v1p3beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p3beta1.IListProductsInProductSetRequest = {};
       request.name = '';

--- a/test/gapic-product_search-v1p4beta1.ts
+++ b/test/gapic-product_search-v1p4beta1.ts
@@ -104,12 +104,30 @@ describe('v1p4beta1.ProductSearchClient', () => {
     });
     assert(client);
   });
+  it('has initialize method and supports deferred initialization', async () => {
+    const client = new productsearchModule.v1p4beta1.ProductSearchClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    assert.strictEqual(client.productSearchStub, undefined);
+    await client.initialize();
+    assert(client.productSearchStub);
+  });
+  it('has close method', () => {
+    const client = new productsearchModule.v1p4beta1.ProductSearchClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    client.close();
+  });
   describe('createProductSet', () => {
     it('invokes createProductSet without error', done => {
       const client = new productsearchModule.v1p4beta1.ProductSearchClient({
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.ICreateProductSetRequest = {};
       request.parent = '';
@@ -133,6 +151,8 @@ describe('v1p4beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.ICreateProductSetRequest = {};
       request.parent = '';
@@ -158,6 +178,8 @@ describe('v1p4beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IGetProductSetRequest = {};
       request.name = '';
@@ -181,6 +203,8 @@ describe('v1p4beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IGetProductSetRequest = {};
       request.name = '';
@@ -206,6 +230,8 @@ describe('v1p4beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IUpdateProductSetRequest = {};
       request.productSet = {};
@@ -230,6 +256,8 @@ describe('v1p4beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IUpdateProductSetRequest = {};
       request.productSet = {};
@@ -256,6 +284,8 @@ describe('v1p4beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IDeleteProductSetRequest = {};
       request.name = '';
@@ -279,6 +309,8 @@ describe('v1p4beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IDeleteProductSetRequest = {};
       request.name = '';
@@ -304,6 +336,8 @@ describe('v1p4beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.ICreateProductRequest = {};
       request.parent = '';
@@ -327,6 +361,8 @@ describe('v1p4beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.ICreateProductRequest = {};
       request.parent = '';
@@ -352,6 +388,8 @@ describe('v1p4beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IGetProductRequest = {};
       request.name = '';
@@ -375,6 +413,8 @@ describe('v1p4beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IGetProductRequest = {};
       request.name = '';
@@ -400,6 +440,8 @@ describe('v1p4beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IUpdateProductRequest = {};
       request.product = {};
@@ -424,6 +466,8 @@ describe('v1p4beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IUpdateProductRequest = {};
       request.product = {};
@@ -450,6 +494,8 @@ describe('v1p4beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IDeleteProductRequest = {};
       request.name = '';
@@ -473,6 +519,8 @@ describe('v1p4beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IDeleteProductRequest = {};
       request.name = '';
@@ -498,6 +546,8 @@ describe('v1p4beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.ICreateReferenceImageRequest = {};
       request.parent = '';
@@ -521,6 +571,8 @@ describe('v1p4beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.ICreateReferenceImageRequest = {};
       request.parent = '';
@@ -546,6 +598,8 @@ describe('v1p4beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IDeleteReferenceImageRequest = {};
       request.name = '';
@@ -569,6 +623,8 @@ describe('v1p4beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IDeleteReferenceImageRequest = {};
       request.name = '';
@@ -594,6 +650,8 @@ describe('v1p4beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IGetReferenceImageRequest = {};
       request.name = '';
@@ -617,6 +675,8 @@ describe('v1p4beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IGetReferenceImageRequest = {};
       request.name = '';
@@ -642,6 +702,8 @@ describe('v1p4beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IAddProductToProductSetRequest = {};
       request.name = '';
@@ -665,6 +727,8 @@ describe('v1p4beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IAddProductToProductSetRequest = {};
       request.name = '';
@@ -690,6 +754,8 @@ describe('v1p4beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IRemoveProductFromProductSetRequest = {};
       request.name = '';
@@ -713,6 +779,8 @@ describe('v1p4beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IRemoveProductFromProductSetRequest = {};
       request.name = '';
@@ -741,6 +809,8 @@ describe('v1p4beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IImportProductSetsRequest = {};
       request.parent = '';
@@ -771,6 +841,8 @@ describe('v1p4beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IImportProductSetsRequest = {};
       request.parent = '';
@@ -804,6 +876,8 @@ describe('v1p4beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IPurgeProductsRequest = {};
       request.parent = '';
@@ -834,6 +908,8 @@ describe('v1p4beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IPurgeProductsRequest = {};
       request.parent = '';
@@ -867,6 +943,8 @@ describe('v1p4beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IListProductSetsRequest = {};
       request.parent = '';
@@ -894,6 +972,8 @@ describe('v1p4beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IListProductSetsRequest = {};
       request.parent = '';
@@ -926,6 +1006,8 @@ describe('v1p4beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IListProductsRequest = {};
       request.parent = '';
@@ -953,6 +1035,8 @@ describe('v1p4beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IListProductsRequest = {};
       request.parent = '';
@@ -985,6 +1069,8 @@ describe('v1p4beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IListReferenceImagesRequest = {};
       request.parent = '';
@@ -1012,6 +1098,8 @@ describe('v1p4beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IListReferenceImagesRequest = {};
       request.parent = '';
@@ -1044,6 +1132,8 @@ describe('v1p4beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IListProductsInProductSetRequest = {};
       request.name = '';
@@ -1074,6 +1164,8 @@ describe('v1p4beta1.ProductSearchClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.vision.v1p4beta1.IListProductsInProductSetRequest = {};
       request.name = '';


### PR DESCRIPTION
This PR includes changes from https://github.com/googleapis/gapic-generator-typescript/pull/317
that will move the asynchronous initialization and authentication from the client constructor
to an `initialize()` method. This method will be automatically called when the first RPC call
is performed.

The client library usage has not changed, there is no need to update any code.

If you want to make sure the client is authenticated _before_ the first RPC call, you can do
```js
await client.initialize();
```
manually before calling any client method.