### PR TITLE
chore: run the generator, fix synth script

### DIFF
--- a/.jsdoc.js
+++ b/.jsdoc.js
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2019 Google, LLC.',
+    copyright: 'Copyright 2020 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: '@google-cloud/vision',

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//      https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "test": "c8 mocha build/test",
     "samples-test": "cd samples/ && npm link ../ && npm install && npm test && cd ../",
-    "lint": "gts fix && eslint --fix samples/*.js",
+    "lint": "gts fix",
     "docs": "jsdoc -c .jsdoc.js",
     "system-test": "mocha build/system-test",
     "fix": "gts fix",
@@ -52,7 +52,6 @@
     "@types/is": "0.0.21",
     "@types/mocha": "^7.0.1",
     "@types/node": "^13.7.4",
-    "@types/is": "0.0.21",
     "@types/sinon": "^9.0.0",
     "@types/uuid": "^3.4.7",
     "c8": "^7.1.0",

--- a/protos/google/cloud/vision/v1/image_annotator.proto
+++ b/protos/google/cloud/vision/v1/image_annotator.proto
@@ -676,7 +676,7 @@ message ImageContext {
   // setting a hint will help get better results (although it will be a
   // significant hindrance if the hint is wrong). Text detection returns an
   // error if one or more of the specified languages is not one of the
-  // [supported languages](/vision/docs/languages).
+  // [supported languages](https://cloud.google.com/vision/docs/languages).
   repeated string language_hints = 2;
 
   // Parameters for crop hints annotation request.

--- a/protos/google/cloud/vision/v1p1beta1/image_annotator.proto
+++ b/protos/google/cloud/vision/v1p1beta1/image_annotator.proto
@@ -502,7 +502,7 @@ message ImageContext {
   // setting a hint will help get better results (although it will be a
   // significant hindrance if the hint is wrong). Text detection returns an
   // error if one or more of the specified languages is not one of the
-  // [supported languages](/vision/docs/languages).
+  // [supported languages](https://cloud.google.com/vision/docs/languages).
   repeated string language_hints = 2;
 
   // Parameters for crop hints annotation request.

--- a/protos/google/cloud/vision/v1p2beta1/image_annotator.proto
+++ b/protos/google/cloud/vision/v1p2beta1/image_annotator.proto
@@ -533,7 +533,7 @@ message ImageContext {
   // setting a hint will help get better results (although it will be a
   // significant hindrance if the hint is wrong). Text detection returns an
   // error if one or more of the specified languages is not one of the
-  // [supported languages](/vision/docs/languages).
+  // [supported languages](https://cloud.google.com/vision/docs/languages).
   repeated string language_hints = 2;
 
   // Parameters for crop hints annotation request.

--- a/protos/google/cloud/vision/v1p3beta1/image_annotator.proto
+++ b/protos/google/cloud/vision/v1p3beta1/image_annotator.proto
@@ -561,7 +561,7 @@ message ImageContext {
   // setting a hint will help get better results (although it will be a
   // significant hindrance if the hint is wrong). Text detection returns an
   // error if one or more of the specified languages is not one of the
-  // [supported languages](/vision/docs/languages).
+  // [supported languages](https://cloud.google.com/vision/docs/languages).
   repeated string language_hints = 2;
 
   // Parameters for crop hints annotation request.

--- a/protos/google/cloud/vision/v1p4beta1/image_annotator.proto
+++ b/protos/google/cloud/vision/v1p4beta1/image_annotator.proto
@@ -632,7 +632,7 @@ message ImageContext {
   // setting a hint will help get better results (although it will be a
   // significant hindrance if the hint is wrong). Text detection returns an
   // error if one or more of the specified languages is not one of the
-  // [supported languages](/vision/docs/languages).
+  // [supported languages](https://cloud.google.com/vision/docs/languages).
   repeated string language_hints = 2;
 
   // Parameters for crop hints annotation request.

--- a/protos/protos.json
+++ b/protos/protos.json
@@ -9017,26 +9017,32 @@
               "extend": "google.protobuf.MethodOptions"
             },
             "Operations": {
+              "options": {
+                "(google.api.default_host)": "longrunning.googleapis.com"
+              },
               "methods": {
                 "ListOperations": {
                   "requestType": "ListOperationsRequest",
                   "responseType": "ListOperationsResponse",
                   "options": {
-                    "(google.api.http).get": "/v1/{name=operations}"
+                    "(google.api.http).get": "/v1/{name=operations}",
+                    "(google.api.method_signature)": "name,filter"
                   }
                 },
                 "GetOperation": {
                   "requestType": "GetOperationRequest",
                   "responseType": "Operation",
                   "options": {
-                    "(google.api.http).get": "/v1/{name=operations/**}"
+                    "(google.api.http).get": "/v1/{name=operations/**}",
+                    "(google.api.method_signature)": "name"
                   }
                 },
                 "DeleteOperation": {
                   "requestType": "DeleteOperationRequest",
                   "responseType": "google.protobuf.Empty",
                   "options": {
-                    "(google.api.http).delete": "/v1/{name=operations/**}"
+                    "(google.api.http).delete": "/v1/{name=operations/**}",
+                    "(google.api.method_signature)": "name"
                   }
                 },
                 "CancelOperation": {
@@ -9044,7 +9050,8 @@
                   "responseType": "google.protobuf.Empty",
                   "options": {
                     "(google.api.http).post": "/v1/{name=operations/**}:cancel",
-                    "(google.api.http).body": "*"
+                    "(google.api.http).body": "*",
+                    "(google.api.method_signature)": "name"
                   }
                 },
                 "WaitOperation": {
@@ -9170,6 +9177,7 @@
         },
         "rpc": {
           "options": {
+            "cc_enable_arenas": true,
             "go_package": "google.golang.org/genproto/googleapis/rpc/status;status",
             "java_multiple_files": true,
             "java_outer_classname": "StatusProto",

--- a/synth.metadata
+++ b/synth.metadata
@@ -1,5 +1,22 @@
 {
-  "updateTime": "2020-03-31T20:16:47.942825Z",
+  "updateTime": "2020-04-10T20:00:59.209374Z",
+  "sources": [
+    {
+      "git": {
+        "name": "googleapis",
+        "remote": "https://github.com/googleapis/googleapis.git",
+        "sha": "cf18ab5200e41e9d0cfef88c6c4bcdd394faf1ca",
+        "internalRef": "305925954"
+      }
+    },
+    {
+      "git": {
+        "name": "synthtool",
+        "remote": "https://github.com/googleapis/synthtool.git",
+        "sha": "6f32150677c9784f3c3a7e1949472bd29c9d72c5"
+      }
+    }
+  ],
   "destinations": [
     {
       "client": {

--- a/synth.py
+++ b/synth.py
@@ -43,7 +43,9 @@ for version in versions:
 for version in versions:
     client_file = f"src/{version}/image_annotator_client.ts"
     s.replace(client_file, '\Z',
-    'import {FeaturesMethod} from \'../helpers\'; \n export interface ImageAnnotatorClient extends FeaturesMethod {}'
+    'import {FeaturesMethod} from \'../helpers\';\n' +
+    '// eslint-disable-next-line @typescript-eslint/no-empty-interface\n' +
+    'export interface ImageAnnotatorClient extends FeaturesMethod {}\n'
     )
 # Copy common templates
 common_templates = gcp.CommonTemplates()

--- a/system-test/vision.ts
+++ b/system-test/vision.ts
@@ -20,7 +20,7 @@ import {Storage} from '@google-cloud/storage';
 import * as uuid from 'uuid';
 import * as prototypes from '../protos/protos';
 import * as vision from '../src';
-// const vision = require('../src');
+
 describe('Vision', () => {
   const IMAGES = Object.freeze({
     document: path.join(

--- a/test/gapic_image_annotator_v1.ts
+++ b/test/gapic_image_annotator_v1.ts
@@ -270,7 +270,7 @@ describe('v1.ImageAnnotatorClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.batchAnnotateImages(request);
       }, expectedError);
       assert(
@@ -386,7 +386,7 @@ describe('v1.ImageAnnotatorClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.batchAnnotateFiles(request);
       }, expectedError);
       assert(
@@ -510,7 +510,7 @@ describe('v1.ImageAnnotatorClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.asyncBatchAnnotateImages(request);
       }, expectedError);
       assert(
@@ -545,7 +545,7 @@ describe('v1.ImageAnnotatorClient', () => {
         expectedError
       );
       const [operation] = await client.asyncBatchAnnotateImages(request);
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await operation.promise();
       }, expectedError);
       assert(
@@ -669,7 +669,7 @@ describe('v1.ImageAnnotatorClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.asyncBatchAnnotateFiles(request);
       }, expectedError);
       assert(
@@ -704,7 +704,7 @@ describe('v1.ImageAnnotatorClient', () => {
         expectedError
       );
       const [operation] = await client.asyncBatchAnnotateFiles(request);
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await operation.promise();
       }, expectedError);
       assert(

--- a/test/gapic_image_annotator_v1p1beta1.ts
+++ b/test/gapic_image_annotator_v1p1beta1.ts
@@ -214,7 +214,7 @@ describe('v1p1beta1.ImageAnnotatorClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.batchAnnotateImages(request);
       }, expectedError);
       assert(

--- a/test/gapic_image_annotator_v1p2beta1.ts
+++ b/test/gapic_image_annotator_v1p2beta1.ts
@@ -246,7 +246,7 @@ describe('v1p2beta1.ImageAnnotatorClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.batchAnnotateImages(request);
       }, expectedError);
       assert(
@@ -346,7 +346,7 @@ describe('v1p2beta1.ImageAnnotatorClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.asyncBatchAnnotateFiles(request);
       }, expectedError);
       assert(
@@ -373,7 +373,7 @@ describe('v1p2beta1.ImageAnnotatorClient', () => {
         expectedError
       );
       const [operation] = await client.asyncBatchAnnotateFiles(request);
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await operation.promise();
       }, expectedError);
       assert(

--- a/test/gapic_image_annotator_v1p3beta1.ts
+++ b/test/gapic_image_annotator_v1p3beta1.ts
@@ -246,7 +246,7 @@ describe('v1p3beta1.ImageAnnotatorClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.batchAnnotateImages(request);
       }, expectedError);
       assert(
@@ -346,7 +346,7 @@ describe('v1p3beta1.ImageAnnotatorClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.asyncBatchAnnotateFiles(request);
       }, expectedError);
       assert(
@@ -373,7 +373,7 @@ describe('v1p3beta1.ImageAnnotatorClient', () => {
         expectedError
       );
       const [operation] = await client.asyncBatchAnnotateFiles(request);
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await operation.promise();
       }, expectedError);
       assert(

--- a/test/gapic_image_annotator_v1p4beta1.ts
+++ b/test/gapic_image_annotator_v1p4beta1.ts
@@ -246,7 +246,7 @@ describe('v1p4beta1.ImageAnnotatorClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.batchAnnotateImages(request);
       }, expectedError);
       assert(
@@ -338,7 +338,7 @@ describe('v1p4beta1.ImageAnnotatorClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.batchAnnotateFiles(request);
       }, expectedError);
       assert(
@@ -438,7 +438,7 @@ describe('v1p4beta1.ImageAnnotatorClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.asyncBatchAnnotateImages(request);
       }, expectedError);
       assert(
@@ -465,7 +465,7 @@ describe('v1p4beta1.ImageAnnotatorClient', () => {
         expectedError
       );
       const [operation] = await client.asyncBatchAnnotateImages(request);
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await operation.promise();
       }, expectedError);
       assert(
@@ -565,7 +565,7 @@ describe('v1p4beta1.ImageAnnotatorClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.asyncBatchAnnotateFiles(request);
       }, expectedError);
       assert(
@@ -592,7 +592,7 @@ describe('v1p4beta1.ImageAnnotatorClient', () => {
         expectedError
       );
       const [operation] = await client.asyncBatchAnnotateFiles(request);
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await operation.promise();
       }, expectedError);
       assert(

--- a/test/gapic_product_search_v1.ts
+++ b/test/gapic_product_search_v1.ts
@@ -329,7 +329,7 @@ describe('v1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.createProductSet(request);
       }, expectedError);
       assert(
@@ -443,7 +443,7 @@ describe('v1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.getProductSet(request);
       }, expectedError);
       assert(
@@ -560,7 +560,7 @@ describe('v1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.updateProductSet(request);
       }, expectedError);
       assert(
@@ -674,7 +674,7 @@ describe('v1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.deleteProductSet(request);
       }, expectedError);
       assert(
@@ -788,7 +788,7 @@ describe('v1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.createProduct(request);
       }, expectedError);
       assert(
@@ -902,7 +902,7 @@ describe('v1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.getProduct(request);
       }, expectedError);
       assert(
@@ -1019,7 +1019,7 @@ describe('v1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.updateProduct(request);
       }, expectedError);
       assert(
@@ -1133,7 +1133,7 @@ describe('v1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.deleteProduct(request);
       }, expectedError);
       assert(
@@ -1249,7 +1249,7 @@ describe('v1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.createReferenceImage(request);
       }, expectedError);
       assert(
@@ -1365,7 +1365,7 @@ describe('v1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.deleteReferenceImage(request);
       }, expectedError);
       assert(
@@ -1479,7 +1479,7 @@ describe('v1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.getReferenceImage(request);
       }, expectedError);
       assert(
@@ -1595,7 +1595,7 @@ describe('v1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.addProductToProductSet(request);
       }, expectedError);
       assert(
@@ -1711,7 +1711,7 @@ describe('v1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.removeProductFromProductSet(request);
       }, expectedError);
       assert(
@@ -1835,7 +1835,7 @@ describe('v1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.importProductSets(request);
       }, expectedError);
       assert(
@@ -1870,7 +1870,7 @@ describe('v1.ProductSearchClient', () => {
         expectedError
       );
       const [operation] = await client.importProductSets(request);
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await operation.promise();
       }, expectedError);
       assert(
@@ -1994,7 +1994,7 @@ describe('v1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.purgeProducts(request);
       }, expectedError);
       assert(
@@ -2029,7 +2029,7 @@ describe('v1.ProductSearchClient', () => {
         expectedError
       );
       const [operation] = await client.purgeProducts(request);
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await operation.promise();
       }, expectedError);
       assert(
@@ -2147,7 +2147,7 @@ describe('v1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.listProductSets(request);
       }, expectedError);
       assert(
@@ -2240,7 +2240,7 @@ describe('v1.ProductSearchClient', () => {
           reject(err);
         });
       });
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await promise;
       }, expectedError);
       assert(
@@ -2313,7 +2313,7 @@ describe('v1.ProductSearchClient', () => {
         expectedError
       );
       const iterable = client.listProductSetsAsync(request);
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         const responses: protos.google.cloud.vision.v1.IProductSet[] = [];
         for await (const resource of iterable) {
           responses.push(resource!);
@@ -2441,7 +2441,7 @@ describe('v1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.listProducts(request);
       }, expectedError);
       assert(
@@ -2528,7 +2528,7 @@ describe('v1.ProductSearchClient', () => {
           reject(err);
         });
       });
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await promise;
       }, expectedError);
       assert(
@@ -2601,7 +2601,7 @@ describe('v1.ProductSearchClient', () => {
         expectedError
       );
       const iterable = client.listProductsAsync(request);
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         const responses: protos.google.cloud.vision.v1.IProduct[] = [];
         for await (const resource of iterable) {
           responses.push(resource!);
@@ -2743,7 +2743,7 @@ describe('v1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.listReferenceImages(request);
       }, expectedError);
       assert(
@@ -2842,7 +2842,7 @@ describe('v1.ProductSearchClient', () => {
           reject(err);
         });
       });
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await promise;
       }, expectedError);
       assert(
@@ -2921,7 +2921,7 @@ describe('v1.ProductSearchClient', () => {
         expectedError
       );
       const iterable = client.listReferenceImagesAsync(request);
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         const responses: protos.google.cloud.vision.v1.IReferenceImage[] = [];
         for await (const resource of iterable) {
           responses.push(resource!);
@@ -3051,7 +3051,7 @@ describe('v1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.listProductsInProductSet(request);
       }, expectedError);
       assert(
@@ -3139,7 +3139,7 @@ describe('v1.ProductSearchClient', () => {
           reject(err);
         });
       });
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await promise;
       }, expectedError);
       assert(
@@ -3213,7 +3213,7 @@ describe('v1.ProductSearchClient', () => {
         expectedError
       );
       const iterable = client.listProductsInProductSetAsync(request);
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         const responses: protos.google.cloud.vision.v1.IProduct[] = [];
         for await (const resource of iterable) {
           responses.push(resource!);

--- a/test/gapic_product_search_v1p3beta1.ts
+++ b/test/gapic_product_search_v1p3beta1.ts
@@ -331,7 +331,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.createProductSet(request);
       }, expectedError);
       assert(
@@ -445,7 +445,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.getProductSet(request);
       }, expectedError);
       assert(
@@ -562,7 +562,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.updateProductSet(request);
       }, expectedError);
       assert(
@@ -676,7 +676,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.deleteProductSet(request);
       }, expectedError);
       assert(
@@ -790,7 +790,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.createProduct(request);
       }, expectedError);
       assert(
@@ -904,7 +904,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.getProduct(request);
       }, expectedError);
       assert(
@@ -1021,7 +1021,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.updateProduct(request);
       }, expectedError);
       assert(
@@ -1135,7 +1135,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.deleteProduct(request);
       }, expectedError);
       assert(
@@ -1251,7 +1251,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.createReferenceImage(request);
       }, expectedError);
       assert(
@@ -1367,7 +1367,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.deleteReferenceImage(request);
       }, expectedError);
       assert(
@@ -1481,7 +1481,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.getReferenceImage(request);
       }, expectedError);
       assert(
@@ -1597,7 +1597,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.addProductToProductSet(request);
       }, expectedError);
       assert(
@@ -1713,7 +1713,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.removeProductFromProductSet(request);
       }, expectedError);
       assert(
@@ -1837,7 +1837,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.importProductSets(request);
       }, expectedError);
       assert(
@@ -1872,7 +1872,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
         expectedError
       );
       const [operation] = await client.importProductSets(request);
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await operation.promise();
       }, expectedError);
       assert(
@@ -2002,7 +2002,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.listProductSets(request);
       }, expectedError);
       assert(
@@ -2101,7 +2101,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
           reject(err);
         });
       });
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await promise;
       }, expectedError);
       assert(
@@ -2180,7 +2180,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
         expectedError
       );
       const iterable = client.listProductSetsAsync(request);
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         const responses: protos.google.cloud.vision.v1p3beta1.IProductSet[] = [];
         for await (const resource of iterable) {
           responses.push(resource!);
@@ -2320,7 +2320,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.listProducts(request);
       }, expectedError);
       assert(
@@ -2419,7 +2419,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
           reject(err);
         });
       });
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await promise;
       }, expectedError);
       assert(
@@ -2498,7 +2498,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
         expectedError
       );
       const iterable = client.listProductsAsync(request);
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         const responses: protos.google.cloud.vision.v1p3beta1.IProduct[] = [];
         for await (const resource of iterable) {
           responses.push(resource!);
@@ -2642,7 +2642,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.listReferenceImages(request);
       }, expectedError);
       assert(
@@ -2741,7 +2741,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
           reject(err);
         });
       });
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await promise;
       }, expectedError);
       assert(
@@ -2820,7 +2820,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
         expectedError
       );
       const iterable = client.listReferenceImagesAsync(request);
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         const responses: protos.google.cloud.vision.v1p3beta1.IReferenceImage[] = [];
         for await (const resource of iterable) {
           responses.push(resource!);
@@ -2962,7 +2962,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.listProductsInProductSet(request);
       }, expectedError);
       assert(
@@ -3062,7 +3062,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
           reject(err);
         });
       });
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await promise;
       }, expectedError);
       assert(
@@ -3142,7 +3142,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
         expectedError
       );
       const iterable = client.listProductsInProductSetAsync(request);
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         const responses: protos.google.cloud.vision.v1p3beta1.IProduct[] = [];
         for await (const resource of iterable) {
           responses.push(resource!);

--- a/test/gapic_product_search_v1p4beta1.ts
+++ b/test/gapic_product_search_v1p4beta1.ts
@@ -331,7 +331,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.createProductSet(request);
       }, expectedError);
       assert(
@@ -445,7 +445,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.getProductSet(request);
       }, expectedError);
       assert(
@@ -562,7 +562,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.updateProductSet(request);
       }, expectedError);
       assert(
@@ -676,7 +676,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.deleteProductSet(request);
       }, expectedError);
       assert(
@@ -790,7 +790,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.createProduct(request);
       }, expectedError);
       assert(
@@ -904,7 +904,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.getProduct(request);
       }, expectedError);
       assert(
@@ -1021,7 +1021,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.updateProduct(request);
       }, expectedError);
       assert(
@@ -1135,7 +1135,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.deleteProduct(request);
       }, expectedError);
       assert(
@@ -1251,7 +1251,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.createReferenceImage(request);
       }, expectedError);
       assert(
@@ -1367,7 +1367,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.deleteReferenceImage(request);
       }, expectedError);
       assert(
@@ -1481,7 +1481,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.getReferenceImage(request);
       }, expectedError);
       assert(
@@ -1597,7 +1597,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.addProductToProductSet(request);
       }, expectedError);
       assert(
@@ -1713,7 +1713,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.removeProductFromProductSet(request);
       }, expectedError);
       assert(
@@ -1837,7 +1837,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.importProductSets(request);
       }, expectedError);
       assert(
@@ -1872,7 +1872,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         expectedError
       );
       const [operation] = await client.importProductSets(request);
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await operation.promise();
       }, expectedError);
       assert(
@@ -1996,7 +1996,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.purgeProducts(request);
       }, expectedError);
       assert(
@@ -2031,7 +2031,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         expectedError
       );
       const [operation] = await client.purgeProducts(request);
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await operation.promise();
       }, expectedError);
       assert(
@@ -2161,7 +2161,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.listProductSets(request);
       }, expectedError);
       assert(
@@ -2260,7 +2260,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
           reject(err);
         });
       });
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await promise;
       }, expectedError);
       assert(
@@ -2339,7 +2339,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         expectedError
       );
       const iterable = client.listProductSetsAsync(request);
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         const responses: protos.google.cloud.vision.v1p4beta1.IProductSet[] = [];
         for await (const resource of iterable) {
           responses.push(resource!);
@@ -2479,7 +2479,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.listProducts(request);
       }, expectedError);
       assert(
@@ -2578,7 +2578,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
           reject(err);
         });
       });
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await promise;
       }, expectedError);
       assert(
@@ -2657,7 +2657,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         expectedError
       );
       const iterable = client.listProductsAsync(request);
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         const responses: protos.google.cloud.vision.v1p4beta1.IProduct[] = [];
         for await (const resource of iterable) {
           responses.push(resource!);
@@ -2801,7 +2801,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.listReferenceImages(request);
       }, expectedError);
       assert(
@@ -2900,7 +2900,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
           reject(err);
         });
       });
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await promise;
       }, expectedError);
       assert(
@@ -2979,7 +2979,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         expectedError
       );
       const iterable = client.listReferenceImagesAsync(request);
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         const responses: protos.google.cloud.vision.v1p4beta1.IReferenceImage[] = [];
         for await (const resource of iterable) {
           responses.push(resource!);
@@ -3121,7 +3121,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await client.listProductsInProductSet(request);
       }, expectedError);
       assert(
@@ -3221,7 +3221,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
           reject(err);
         });
       });
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await promise;
       }, expectedError);
       assert(
@@ -3301,7 +3301,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         expectedError
       );
       const iterable = client.listProductsInProductSetAsync(request);
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         const responses: protos.google.cloud.vision.v1p4beta1.IProduct[] = [];
         for await (const resource of iterable) {
           responses.push(resource!);


### PR DESCRIPTION
We have a ❄️ `synth.py` here (because of manual helpers) and it turned out the `eslint-disable` rule was added directly to the autogenerated code in #568 (I'm delighted to report that it was me who screwed up :) )

Fixing it properly, by making sure the `eslint-disable` won't get overwritten.