### PR TITLE
feat: check status of long running operation by its name

### DIFF
--- a/src/v1/image_annotator_client.ts
+++ b/src/v1/image_annotator_client.ts
@@ -28,7 +28,7 @@ import * as path from 'path';
 
 import * as protos from '../../protos/protos';
 import * as gapicConfig from './image_annotator_client_config.json';
-
+import {operationsProtos} from 'google-gax';
 const version = require('../../../package.json').version;
 
 /**
@@ -684,6 +684,42 @@ export class ImageAnnotatorClient {
       callback
     );
   }
+  /**
+   * Check the status of the long running operation returned by the asyncBatchAnnotateImages() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkAsyncBatchAnnotateImagesProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkAsyncBatchAnnotateImagesProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.cloud.vision.v1.AsyncBatchAnnotateImagesResponse,
+      protos.google.cloud.vision.v1.OperationMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.asyncBatchAnnotateImages,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.cloud.vision.v1.AsyncBatchAnnotateImagesResponse,
+      protos.google.cloud.vision.v1.OperationMetadata
+    >;
+  }
   asyncBatchAnnotateFiles(
     request: protos.google.cloud.vision.v1.IAsyncBatchAnnotateFilesRequest,
     options?: gax.CallOptions
@@ -803,6 +839,42 @@ export class ImageAnnotatorClient {
       options,
       callback
     );
+  }
+  /**
+   * Check the status of the long running operation returned by the asyncBatchAnnotateFiles() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkAsyncBatchAnnotateFilesProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkAsyncBatchAnnotateFilesProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.cloud.vision.v1.AsyncBatchAnnotateFilesResponse,
+      protos.google.cloud.vision.v1.OperationMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.asyncBatchAnnotateFiles,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.cloud.vision.v1.AsyncBatchAnnotateFilesResponse,
+      protos.google.cloud.vision.v1.OperationMetadata
+    >;
   }
   // --------------------
   // -- Path templates --

--- a/src/v1/product_search_client.ts
+++ b/src/v1/product_search_client.ts
@@ -32,7 +32,7 @@ import {Transform} from 'stream';
 import {RequestType} from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
 import * as gapicConfig from './product_search_client_config.json';
-
+import {operationsProtos} from 'google-gax';
 const version = require('../../../package.json').version;
 
 /**
@@ -1782,6 +1782,42 @@ export class ProductSearchClient {
     this.initialize();
     return this.innerApiCalls.importProductSets(request, options, callback);
   }
+  /**
+   * Check the status of the long running operation returned by the importProductSets() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkImportProductSetsProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkImportProductSetsProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.cloud.vision.v1.ImportProductSetsResponse,
+      protos.google.cloud.vision.v1.BatchOperationMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.importProductSets,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.cloud.vision.v1.ImportProductSetsResponse,
+      protos.google.cloud.vision.v1.BatchOperationMetadata
+    >;
+  }
   purgeProducts(
     request: protos.google.cloud.vision.v1.IPurgeProductsRequest,
     options?: gax.CallOptions
@@ -1912,6 +1948,42 @@ export class ProductSearchClient {
     });
     this.initialize();
     return this.innerApiCalls.purgeProducts(request, options, callback);
+  }
+  /**
+   * Check the status of the long running operation returned by the purgeProducts() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkPurgeProductsProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkPurgeProductsProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.cloud.vision.v1.BatchOperationMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.purgeProducts,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.cloud.vision.v1.BatchOperationMetadata
+    >;
   }
   listProductSets(
     request: protos.google.cloud.vision.v1.IListProductSetsRequest,

--- a/src/v1p2beta1/image_annotator_client.ts
+++ b/src/v1p2beta1/image_annotator_client.ts
@@ -28,7 +28,7 @@ import * as path from 'path';
 
 import * as protos from '../../protos/protos';
 import * as gapicConfig from './image_annotator_client_config.json';
-
+import {operationsProtos} from 'google-gax';
 const version = require('../../../package.json').version;
 
 /**
@@ -503,6 +503,42 @@ export class ImageAnnotatorClient {
       options,
       callback
     );
+  }
+  /**
+   * Check the status of the long running operation returned by the asyncBatchAnnotateFiles() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkAsyncBatchAnnotateFilesProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkAsyncBatchAnnotateFilesProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.cloud.vision.v1p2beta1.AsyncBatchAnnotateFilesResponse,
+      protos.google.cloud.vision.v1p2beta1.OperationMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.asyncBatchAnnotateFiles,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.cloud.vision.v1p2beta1.AsyncBatchAnnotateFilesResponse,
+      protos.google.cloud.vision.v1p2beta1.OperationMetadata
+    >;
   }
 
   /**

--- a/src/v1p3beta1/image_annotator_client.ts
+++ b/src/v1p3beta1/image_annotator_client.ts
@@ -28,7 +28,7 @@ import * as path from 'path';
 
 import * as protos from '../../protos/protos';
 import * as gapicConfig from './image_annotator_client_config.json';
-
+import {operationsProtos} from 'google-gax';
 const version = require('../../../package.json').version;
 
 /**
@@ -519,6 +519,42 @@ export class ImageAnnotatorClient {
       options,
       callback
     );
+  }
+  /**
+   * Check the status of the long running operation returned by the asyncBatchAnnotateFiles() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkAsyncBatchAnnotateFilesProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkAsyncBatchAnnotateFilesProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.cloud.vision.v1p3beta1.AsyncBatchAnnotateFilesResponse,
+      protos.google.cloud.vision.v1p3beta1.OperationMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.asyncBatchAnnotateFiles,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.cloud.vision.v1p3beta1.AsyncBatchAnnotateFilesResponse,
+      protos.google.cloud.vision.v1p3beta1.OperationMetadata
+    >;
   }
   // --------------------
   // -- Path templates --

--- a/src/v1p3beta1/product_search_client.ts
+++ b/src/v1p3beta1/product_search_client.ts
@@ -32,7 +32,7 @@ import {Transform} from 'stream';
 import {RequestType} from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
 import * as gapicConfig from './product_search_client_config.json';
-
+import {operationsProtos} from 'google-gax';
 const version = require('../../../package.json').version;
 
 /**
@@ -1858,6 +1858,42 @@ export class ProductSearchClient {
     });
     this.initialize();
     return this.innerApiCalls.importProductSets(request, options, callback);
+  }
+  /**
+   * Check the status of the long running operation returned by the importProductSets() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkImportProductSetsProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkImportProductSetsProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.cloud.vision.v1p3beta1.ImportProductSetsResponse,
+      protos.google.cloud.vision.v1p3beta1.BatchOperationMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.importProductSets,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.cloud.vision.v1p3beta1.ImportProductSetsResponse,
+      protos.google.cloud.vision.v1p3beta1.BatchOperationMetadata
+    >;
   }
   listProductSets(
     request: protos.google.cloud.vision.v1p3beta1.IListProductSetsRequest,

--- a/src/v1p4beta1/image_annotator_client.ts
+++ b/src/v1p4beta1/image_annotator_client.ts
@@ -28,7 +28,7 @@ import * as path from 'path';
 
 import * as protos from '../../protos/protos';
 import * as gapicConfig from './image_annotator_client_config.json';
-
+import {operationsProtos} from 'google-gax';
 const version = require('../../../package.json').version;
 
 /**
@@ -636,6 +636,42 @@ export class ImageAnnotatorClient {
       callback
     );
   }
+  /**
+   * Check the status of the long running operation returned by the asyncBatchAnnotateImages() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkAsyncBatchAnnotateImagesProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkAsyncBatchAnnotateImagesProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.cloud.vision.v1p4beta1.AsyncBatchAnnotateImagesResponse,
+      protos.google.cloud.vision.v1p4beta1.OperationMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.asyncBatchAnnotateImages,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.cloud.vision.v1p4beta1.AsyncBatchAnnotateImagesResponse,
+      protos.google.cloud.vision.v1p4beta1.OperationMetadata
+    >;
+  }
   asyncBatchAnnotateFiles(
     request: protos.google.cloud.vision.v1p4beta1.IAsyncBatchAnnotateFilesRequest,
     options?: gax.CallOptions
@@ -735,6 +771,42 @@ export class ImageAnnotatorClient {
       options,
       callback
     );
+  }
+  /**
+   * Check the status of the long running operation returned by the asyncBatchAnnotateFiles() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkAsyncBatchAnnotateFilesProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkAsyncBatchAnnotateFilesProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.cloud.vision.v1p4beta1.AsyncBatchAnnotateFilesResponse,
+      protos.google.cloud.vision.v1p4beta1.OperationMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.asyncBatchAnnotateFiles,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.cloud.vision.v1p4beta1.AsyncBatchAnnotateFilesResponse,
+      protos.google.cloud.vision.v1p4beta1.OperationMetadata
+    >;
   }
   // --------------------
   // -- Path templates --

--- a/src/v1p4beta1/product_search_client.ts
+++ b/src/v1p4beta1/product_search_client.ts
@@ -32,7 +32,7 @@ import {Transform} from 'stream';
 import {RequestType} from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
 import * as gapicConfig from './product_search_client_config.json';
-
+import {operationsProtos} from 'google-gax';
 const version = require('../../../package.json').version;
 
 /**
@@ -1862,6 +1862,42 @@ export class ProductSearchClient {
     this.initialize();
     return this.innerApiCalls.importProductSets(request, options, callback);
   }
+  /**
+   * Check the status of the long running operation returned by the importProductSets() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkImportProductSetsProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkImportProductSetsProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.cloud.vision.v1p4beta1.ImportProductSetsResponse,
+      protos.google.cloud.vision.v1p4beta1.BatchOperationMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.importProductSets,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.cloud.vision.v1p4beta1.ImportProductSetsResponse,
+      protos.google.cloud.vision.v1p4beta1.BatchOperationMetadata
+    >;
+  }
   purgeProducts(
     request: protos.google.cloud.vision.v1p4beta1.IPurgeProductsRequest,
     options?: gax.CallOptions
@@ -1992,6 +2028,42 @@ export class ProductSearchClient {
     });
     this.initialize();
     return this.innerApiCalls.purgeProducts(request, options, callback);
+  }
+  /**
+   * Check the status of the long running operation returned by the purgeProducts() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkPurgeProductsProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkPurgeProductsProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.cloud.vision.v1p4beta1.BatchOperationMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.purgeProducts,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.cloud.vision.v1p4beta1.BatchOperationMetadata
+    >;
   }
   listProductSets(
     request: protos.google.cloud.vision.v1p4beta1.IListProductSetsRequest,

--- a/synth.metadata
+++ b/synth.metadata
@@ -3,23 +3,15 @@
     {
       "git": {
         "name": ".",
-        "remote": "https://github.com/googleapis/nodejs-vision.git",
-        "sha": "5dee7d0b08872829ea4821d7d7293e8b824b8330"
-      }
-    },
-    {
-      "git": {
-        "name": "googleapis",
-        "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "42ee97c1b93a0e3759bbba3013da309f670a90ab",
-        "internalRef": "307114445"
+        "remote": "git@github.com:googleapis/nodejs-vision.git",
+        "sha": "44a8dcc389489829f927015a1070e516f2e786b0"
       }
     },
     {
       "git": {
         "name": "synthtool",
         "remote": "https://github.com/googleapis/synthtool.git",
-        "sha": "19465d3ec5e5acdb01521d8f3bddd311bcbee28d"
+        "sha": "ab883569eb0257bbf16a6d825fd018b3adde3912"
       }
     }
   ],

--- a/test/gapic_image_annotator_v1.ts
+++ b/test/gapic_image_annotator_v1.ts
@@ -23,7 +23,7 @@ import {SinonStub} from 'sinon';
 import {describe, it} from 'mocha';
 import * as imageannotatorModule from '../src';
 
-import {protobuf, LROperation} from 'google-gax';
+import {protobuf, LROperation, operationsProtos} from 'google-gax';
 
 function generateSampleMessage<T extends object>(instance: T) {
   const filledObject = (instance.constructor as typeof protobuf.Message).toObject(
@@ -270,9 +270,7 @@ describe('v1.ImageAnnotatorClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.batchAnnotateImages(request);
-      }, expectedError);
+      await assert.rejects(client.batchAnnotateImages(request), expectedError);
       assert(
         (client.innerApiCalls.batchAnnotateImages as SinonStub)
           .getCall(0)
@@ -386,9 +384,7 @@ describe('v1.ImageAnnotatorClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.batchAnnotateFiles(request);
-      }, expectedError);
+      await assert.rejects(client.batchAnnotateFiles(request), expectedError);
       assert(
         (client.innerApiCalls.batchAnnotateFiles as SinonStub)
           .getCall(0)
@@ -510,9 +506,10 @@ describe('v1.ImageAnnotatorClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.asyncBatchAnnotateImages(request);
-      }, expectedError);
+      await assert.rejects(
+        client.asyncBatchAnnotateImages(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.asyncBatchAnnotateImages as SinonStub)
           .getCall(0)
@@ -545,14 +542,53 @@ describe('v1.ImageAnnotatorClient', () => {
         expectedError
       );
       const [operation] = await client.asyncBatchAnnotateImages(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.asyncBatchAnnotateImages as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkAsyncBatchAnnotateImagesProgress without error', async () => {
+      const client = new imageannotatorModule.v1.ImageAnnotatorClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkAsyncBatchAnnotateImagesProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkAsyncBatchAnnotateImagesProgress with error', async () => {
+      const client = new imageannotatorModule.v1.ImageAnnotatorClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkAsyncBatchAnnotateImagesProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -669,9 +705,10 @@ describe('v1.ImageAnnotatorClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.asyncBatchAnnotateFiles(request);
-      }, expectedError);
+      await assert.rejects(
+        client.asyncBatchAnnotateFiles(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.asyncBatchAnnotateFiles as SinonStub)
           .getCall(0)
@@ -704,14 +741,53 @@ describe('v1.ImageAnnotatorClient', () => {
         expectedError
       );
       const [operation] = await client.asyncBatchAnnotateFiles(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.asyncBatchAnnotateFiles as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkAsyncBatchAnnotateFilesProgress without error', async () => {
+      const client = new imageannotatorModule.v1.ImageAnnotatorClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkAsyncBatchAnnotateFilesProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkAsyncBatchAnnotateFilesProgress with error', async () => {
+      const client = new imageannotatorModule.v1.ImageAnnotatorClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkAsyncBatchAnnotateFilesProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 

--- a/test/gapic_image_annotator_v1p1beta1.ts
+++ b/test/gapic_image_annotator_v1p1beta1.ts
@@ -214,9 +214,7 @@ describe('v1p1beta1.ImageAnnotatorClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.batchAnnotateImages(request);
-      }, expectedError);
+      await assert.rejects(client.batchAnnotateImages(request), expectedError);
       assert(
         (client.innerApiCalls.batchAnnotateImages as SinonStub)
           .getCall(0)

--- a/test/gapic_image_annotator_v1p2beta1.ts
+++ b/test/gapic_image_annotator_v1p2beta1.ts
@@ -23,7 +23,7 @@ import {SinonStub} from 'sinon';
 import {describe, it} from 'mocha';
 import * as imageannotatorModule from '../src';
 
-import {protobuf, LROperation} from 'google-gax';
+import {protobuf, LROperation, operationsProtos} from 'google-gax';
 
 function generateSampleMessage<T extends object>(instance: T) {
   const filledObject = (instance.constructor as typeof protobuf.Message).toObject(
@@ -246,9 +246,7 @@ describe('v1p2beta1.ImageAnnotatorClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.batchAnnotateImages(request);
-      }, expectedError);
+      await assert.rejects(client.batchAnnotateImages(request), expectedError);
       assert(
         (client.innerApiCalls.batchAnnotateImages as SinonStub)
           .getCall(0)
@@ -346,9 +344,10 @@ describe('v1p2beta1.ImageAnnotatorClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.asyncBatchAnnotateFiles(request);
-      }, expectedError);
+      await assert.rejects(
+        client.asyncBatchAnnotateFiles(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.asyncBatchAnnotateFiles as SinonStub)
           .getCall(0)
@@ -373,14 +372,53 @@ describe('v1p2beta1.ImageAnnotatorClient', () => {
         expectedError
       );
       const [operation] = await client.asyncBatchAnnotateFiles(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.asyncBatchAnnotateFiles as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkAsyncBatchAnnotateFilesProgress without error', async () => {
+      const client = new imageannotatorModule.v1p2beta1.ImageAnnotatorClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkAsyncBatchAnnotateFilesProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkAsyncBatchAnnotateFilesProgress with error', async () => {
+      const client = new imageannotatorModule.v1p2beta1.ImageAnnotatorClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkAsyncBatchAnnotateFilesProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 });

--- a/test/gapic_image_annotator_v1p3beta1.ts
+++ b/test/gapic_image_annotator_v1p3beta1.ts
@@ -23,7 +23,7 @@ import {SinonStub} from 'sinon';
 import {describe, it} from 'mocha';
 import * as imageannotatorModule from '../src';
 
-import {protobuf, LROperation} from 'google-gax';
+import {protobuf, LROperation, operationsProtos} from 'google-gax';
 
 function generateSampleMessage<T extends object>(instance: T) {
   const filledObject = (instance.constructor as typeof protobuf.Message).toObject(
@@ -246,9 +246,7 @@ describe('v1p3beta1.ImageAnnotatorClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.batchAnnotateImages(request);
-      }, expectedError);
+      await assert.rejects(client.batchAnnotateImages(request), expectedError);
       assert(
         (client.innerApiCalls.batchAnnotateImages as SinonStub)
           .getCall(0)
@@ -346,9 +344,10 @@ describe('v1p3beta1.ImageAnnotatorClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.asyncBatchAnnotateFiles(request);
-      }, expectedError);
+      await assert.rejects(
+        client.asyncBatchAnnotateFiles(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.asyncBatchAnnotateFiles as SinonStub)
           .getCall(0)
@@ -373,14 +372,53 @@ describe('v1p3beta1.ImageAnnotatorClient', () => {
         expectedError
       );
       const [operation] = await client.asyncBatchAnnotateFiles(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.asyncBatchAnnotateFiles as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkAsyncBatchAnnotateFilesProgress without error', async () => {
+      const client = new imageannotatorModule.v1p3beta1.ImageAnnotatorClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkAsyncBatchAnnotateFilesProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkAsyncBatchAnnotateFilesProgress with error', async () => {
+      const client = new imageannotatorModule.v1p3beta1.ImageAnnotatorClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkAsyncBatchAnnotateFilesProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 

--- a/test/gapic_image_annotator_v1p4beta1.ts
+++ b/test/gapic_image_annotator_v1p4beta1.ts
@@ -23,7 +23,7 @@ import {SinonStub} from 'sinon';
 import {describe, it} from 'mocha';
 import * as imageannotatorModule from '../src';
 
-import {protobuf, LROperation} from 'google-gax';
+import {protobuf, LROperation, operationsProtos} from 'google-gax';
 
 function generateSampleMessage<T extends object>(instance: T) {
   const filledObject = (instance.constructor as typeof protobuf.Message).toObject(
@@ -246,9 +246,7 @@ describe('v1p4beta1.ImageAnnotatorClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.batchAnnotateImages(request);
-      }, expectedError);
+      await assert.rejects(client.batchAnnotateImages(request), expectedError);
       assert(
         (client.innerApiCalls.batchAnnotateImages as SinonStub)
           .getCall(0)
@@ -338,9 +336,7 @@ describe('v1p4beta1.ImageAnnotatorClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.batchAnnotateFiles(request);
-      }, expectedError);
+      await assert.rejects(client.batchAnnotateFiles(request), expectedError);
       assert(
         (client.innerApiCalls.batchAnnotateFiles as SinonStub)
           .getCall(0)
@@ -438,9 +434,10 @@ describe('v1p4beta1.ImageAnnotatorClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.asyncBatchAnnotateImages(request);
-      }, expectedError);
+      await assert.rejects(
+        client.asyncBatchAnnotateImages(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.asyncBatchAnnotateImages as SinonStub)
           .getCall(0)
@@ -465,14 +462,53 @@ describe('v1p4beta1.ImageAnnotatorClient', () => {
         expectedError
       );
       const [operation] = await client.asyncBatchAnnotateImages(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.asyncBatchAnnotateImages as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkAsyncBatchAnnotateImagesProgress without error', async () => {
+      const client = new imageannotatorModule.v1p4beta1.ImageAnnotatorClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkAsyncBatchAnnotateImagesProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkAsyncBatchAnnotateImagesProgress with error', async () => {
+      const client = new imageannotatorModule.v1p4beta1.ImageAnnotatorClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkAsyncBatchAnnotateImagesProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -565,9 +601,10 @@ describe('v1p4beta1.ImageAnnotatorClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.asyncBatchAnnotateFiles(request);
-      }, expectedError);
+      await assert.rejects(
+        client.asyncBatchAnnotateFiles(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.asyncBatchAnnotateFiles as SinonStub)
           .getCall(0)
@@ -592,14 +629,53 @@ describe('v1p4beta1.ImageAnnotatorClient', () => {
         expectedError
       );
       const [operation] = await client.asyncBatchAnnotateFiles(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.asyncBatchAnnotateFiles as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkAsyncBatchAnnotateFilesProgress without error', async () => {
+      const client = new imageannotatorModule.v1p4beta1.ImageAnnotatorClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkAsyncBatchAnnotateFilesProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkAsyncBatchAnnotateFilesProgress with error', async () => {
+      const client = new imageannotatorModule.v1p4beta1.ImageAnnotatorClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkAsyncBatchAnnotateFilesProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 

--- a/test/gapic_product_search_v1.ts
+++ b/test/gapic_product_search_v1.ts
@@ -25,7 +25,7 @@ import * as productsearchModule from '../src';
 
 import {PassThrough} from 'stream';
 
-import {protobuf, LROperation} from 'google-gax';
+import {protobuf, LROperation, operationsProtos} from 'google-gax';
 
 function generateSampleMessage<T extends object>(instance: T) {
   const filledObject = (instance.constructor as typeof protobuf.Message).toObject(
@@ -329,9 +329,7 @@ describe('v1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.createProductSet(request);
-      }, expectedError);
+      await assert.rejects(client.createProductSet(request), expectedError);
       assert(
         (client.innerApiCalls.createProductSet as SinonStub)
           .getCall(0)
@@ -443,9 +441,7 @@ describe('v1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getProductSet(request);
-      }, expectedError);
+      await assert.rejects(client.getProductSet(request), expectedError);
       assert(
         (client.innerApiCalls.getProductSet as SinonStub)
           .getCall(0)
@@ -560,9 +556,7 @@ describe('v1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.updateProductSet(request);
-      }, expectedError);
+      await assert.rejects(client.updateProductSet(request), expectedError);
       assert(
         (client.innerApiCalls.updateProductSet as SinonStub)
           .getCall(0)
@@ -674,9 +668,7 @@ describe('v1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.deleteProductSet(request);
-      }, expectedError);
+      await assert.rejects(client.deleteProductSet(request), expectedError);
       assert(
         (client.innerApiCalls.deleteProductSet as SinonStub)
           .getCall(0)
@@ -788,9 +780,7 @@ describe('v1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.createProduct(request);
-      }, expectedError);
+      await assert.rejects(client.createProduct(request), expectedError);
       assert(
         (client.innerApiCalls.createProduct as SinonStub)
           .getCall(0)
@@ -902,9 +892,7 @@ describe('v1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getProduct(request);
-      }, expectedError);
+      await assert.rejects(client.getProduct(request), expectedError);
       assert(
         (client.innerApiCalls.getProduct as SinonStub)
           .getCall(0)
@@ -1019,9 +1007,7 @@ describe('v1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.updateProduct(request);
-      }, expectedError);
+      await assert.rejects(client.updateProduct(request), expectedError);
       assert(
         (client.innerApiCalls.updateProduct as SinonStub)
           .getCall(0)
@@ -1133,9 +1119,7 @@ describe('v1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.deleteProduct(request);
-      }, expectedError);
+      await assert.rejects(client.deleteProduct(request), expectedError);
       assert(
         (client.innerApiCalls.deleteProduct as SinonStub)
           .getCall(0)
@@ -1249,9 +1233,7 @@ describe('v1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.createReferenceImage(request);
-      }, expectedError);
+      await assert.rejects(client.createReferenceImage(request), expectedError);
       assert(
         (client.innerApiCalls.createReferenceImage as SinonStub)
           .getCall(0)
@@ -1365,9 +1347,7 @@ describe('v1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.deleteReferenceImage(request);
-      }, expectedError);
+      await assert.rejects(client.deleteReferenceImage(request), expectedError);
       assert(
         (client.innerApiCalls.deleteReferenceImage as SinonStub)
           .getCall(0)
@@ -1479,9 +1459,7 @@ describe('v1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getReferenceImage(request);
-      }, expectedError);
+      await assert.rejects(client.getReferenceImage(request), expectedError);
       assert(
         (client.innerApiCalls.getReferenceImage as SinonStub)
           .getCall(0)
@@ -1595,9 +1573,10 @@ describe('v1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.addProductToProductSet(request);
-      }, expectedError);
+      await assert.rejects(
+        client.addProductToProductSet(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.addProductToProductSet as SinonStub)
           .getCall(0)
@@ -1711,9 +1690,10 @@ describe('v1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.removeProductFromProductSet(request);
-      }, expectedError);
+      await assert.rejects(
+        client.removeProductFromProductSet(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.removeProductFromProductSet as SinonStub)
           .getCall(0)
@@ -1835,9 +1815,7 @@ describe('v1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.importProductSets(request);
-      }, expectedError);
+      await assert.rejects(client.importProductSets(request), expectedError);
       assert(
         (client.innerApiCalls.importProductSets as SinonStub)
           .getCall(0)
@@ -1870,14 +1848,53 @@ describe('v1.ProductSearchClient', () => {
         expectedError
       );
       const [operation] = await client.importProductSets(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.importProductSets as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkImportProductSetsProgress without error', async () => {
+      const client = new productsearchModule.v1.ProductSearchClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkImportProductSetsProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkImportProductSetsProgress with error', async () => {
+      const client = new productsearchModule.v1.ProductSearchClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkImportProductSetsProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -1994,9 +2011,7 @@ describe('v1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.purgeProducts(request);
-      }, expectedError);
+      await assert.rejects(client.purgeProducts(request), expectedError);
       assert(
         (client.innerApiCalls.purgeProducts as SinonStub)
           .getCall(0)
@@ -2029,14 +2044,53 @@ describe('v1.ProductSearchClient', () => {
         expectedError
       );
       const [operation] = await client.purgeProducts(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.purgeProducts as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkPurgeProductsProgress without error', async () => {
+      const client = new productsearchModule.v1.ProductSearchClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkPurgeProductsProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkPurgeProductsProgress with error', async () => {
+      const client = new productsearchModule.v1.ProductSearchClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkPurgeProductsProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -2147,9 +2201,7 @@ describe('v1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listProductSets(request);
-      }, expectedError);
+      await assert.rejects(client.listProductSets(request), expectedError);
       assert(
         (client.innerApiCalls.listProductSets as SinonStub)
           .getCall(0)
@@ -2240,9 +2292,7 @@ describe('v1.ProductSearchClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listProductSets.createStream as SinonStub)
           .getCall(0)
@@ -2441,9 +2491,7 @@ describe('v1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listProducts(request);
-      }, expectedError);
+      await assert.rejects(client.listProducts(request), expectedError);
       assert(
         (client.innerApiCalls.listProducts as SinonStub)
           .getCall(0)
@@ -2528,9 +2576,7 @@ describe('v1.ProductSearchClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listProducts.createStream as SinonStub)
           .getCall(0)
@@ -2743,9 +2789,7 @@ describe('v1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listReferenceImages(request);
-      }, expectedError);
+      await assert.rejects(client.listReferenceImages(request), expectedError);
       assert(
         (client.innerApiCalls.listReferenceImages as SinonStub)
           .getCall(0)
@@ -2842,9 +2886,7 @@ describe('v1.ProductSearchClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listReferenceImages.createStream as SinonStub)
           .getCall(0)
@@ -3051,9 +3093,10 @@ describe('v1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listProductsInProductSet(request);
-      }, expectedError);
+      await assert.rejects(
+        client.listProductsInProductSet(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.listProductsInProductSet as SinonStub)
           .getCall(0)
@@ -3139,9 +3182,7 @@ describe('v1.ProductSearchClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listProductsInProductSet
           .createStream as SinonStub)

--- a/test/gapic_product_search_v1p3beta1.ts
+++ b/test/gapic_product_search_v1p3beta1.ts
@@ -25,7 +25,7 @@ import * as productsearchModule from '../src';
 
 import {PassThrough} from 'stream';
 
-import {protobuf, LROperation} from 'google-gax';
+import {protobuf, LROperation, operationsProtos} from 'google-gax';
 
 function generateSampleMessage<T extends object>(instance: T) {
   const filledObject = (instance.constructor as typeof protobuf.Message).toObject(
@@ -331,9 +331,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.createProductSet(request);
-      }, expectedError);
+      await assert.rejects(client.createProductSet(request), expectedError);
       assert(
         (client.innerApiCalls.createProductSet as SinonStub)
           .getCall(0)
@@ -445,9 +443,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getProductSet(request);
-      }, expectedError);
+      await assert.rejects(client.getProductSet(request), expectedError);
       assert(
         (client.innerApiCalls.getProductSet as SinonStub)
           .getCall(0)
@@ -562,9 +558,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.updateProductSet(request);
-      }, expectedError);
+      await assert.rejects(client.updateProductSet(request), expectedError);
       assert(
         (client.innerApiCalls.updateProductSet as SinonStub)
           .getCall(0)
@@ -676,9 +670,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.deleteProductSet(request);
-      }, expectedError);
+      await assert.rejects(client.deleteProductSet(request), expectedError);
       assert(
         (client.innerApiCalls.deleteProductSet as SinonStub)
           .getCall(0)
@@ -790,9 +782,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.createProduct(request);
-      }, expectedError);
+      await assert.rejects(client.createProduct(request), expectedError);
       assert(
         (client.innerApiCalls.createProduct as SinonStub)
           .getCall(0)
@@ -904,9 +894,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getProduct(request);
-      }, expectedError);
+      await assert.rejects(client.getProduct(request), expectedError);
       assert(
         (client.innerApiCalls.getProduct as SinonStub)
           .getCall(0)
@@ -1021,9 +1009,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.updateProduct(request);
-      }, expectedError);
+      await assert.rejects(client.updateProduct(request), expectedError);
       assert(
         (client.innerApiCalls.updateProduct as SinonStub)
           .getCall(0)
@@ -1135,9 +1121,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.deleteProduct(request);
-      }, expectedError);
+      await assert.rejects(client.deleteProduct(request), expectedError);
       assert(
         (client.innerApiCalls.deleteProduct as SinonStub)
           .getCall(0)
@@ -1251,9 +1235,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.createReferenceImage(request);
-      }, expectedError);
+      await assert.rejects(client.createReferenceImage(request), expectedError);
       assert(
         (client.innerApiCalls.createReferenceImage as SinonStub)
           .getCall(0)
@@ -1367,9 +1349,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.deleteReferenceImage(request);
-      }, expectedError);
+      await assert.rejects(client.deleteReferenceImage(request), expectedError);
       assert(
         (client.innerApiCalls.deleteReferenceImage as SinonStub)
           .getCall(0)
@@ -1481,9 +1461,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getReferenceImage(request);
-      }, expectedError);
+      await assert.rejects(client.getReferenceImage(request), expectedError);
       assert(
         (client.innerApiCalls.getReferenceImage as SinonStub)
           .getCall(0)
@@ -1597,9 +1575,10 @@ describe('v1p3beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.addProductToProductSet(request);
-      }, expectedError);
+      await assert.rejects(
+        client.addProductToProductSet(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.addProductToProductSet as SinonStub)
           .getCall(0)
@@ -1713,9 +1692,10 @@ describe('v1p3beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.removeProductFromProductSet(request);
-      }, expectedError);
+      await assert.rejects(
+        client.removeProductFromProductSet(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.removeProductFromProductSet as SinonStub)
           .getCall(0)
@@ -1837,9 +1817,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.importProductSets(request);
-      }, expectedError);
+      await assert.rejects(client.importProductSets(request), expectedError);
       assert(
         (client.innerApiCalls.importProductSets as SinonStub)
           .getCall(0)
@@ -1872,14 +1850,53 @@ describe('v1p3beta1.ProductSearchClient', () => {
         expectedError
       );
       const [operation] = await client.importProductSets(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.importProductSets as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkImportProductSetsProgress without error', async () => {
+      const client = new productsearchModule.v1p3beta1.ProductSearchClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkImportProductSetsProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkImportProductSetsProgress with error', async () => {
+      const client = new productsearchModule.v1p3beta1.ProductSearchClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkImportProductSetsProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -2002,9 +2019,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listProductSets(request);
-      }, expectedError);
+      await assert.rejects(client.listProductSets(request), expectedError);
       assert(
         (client.innerApiCalls.listProductSets as SinonStub)
           .getCall(0)
@@ -2101,9 +2116,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listProductSets.createStream as SinonStub)
           .getCall(0)
@@ -2320,9 +2333,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listProducts(request);
-      }, expectedError);
+      await assert.rejects(client.listProducts(request), expectedError);
       assert(
         (client.innerApiCalls.listProducts as SinonStub)
           .getCall(0)
@@ -2419,9 +2430,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listProducts.createStream as SinonStub)
           .getCall(0)
@@ -2642,9 +2651,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listReferenceImages(request);
-      }, expectedError);
+      await assert.rejects(client.listReferenceImages(request), expectedError);
       assert(
         (client.innerApiCalls.listReferenceImages as SinonStub)
           .getCall(0)
@@ -2741,9 +2748,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listReferenceImages.createStream as SinonStub)
           .getCall(0)
@@ -2962,9 +2967,10 @@ describe('v1p3beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listProductsInProductSet(request);
-      }, expectedError);
+      await assert.rejects(
+        client.listProductsInProductSet(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.listProductsInProductSet as SinonStub)
           .getCall(0)
@@ -3062,9 +3068,7 @@ describe('v1p3beta1.ProductSearchClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listProductsInProductSet
           .createStream as SinonStub)

--- a/test/gapic_product_search_v1p4beta1.ts
+++ b/test/gapic_product_search_v1p4beta1.ts
@@ -25,7 +25,7 @@ import * as productsearchModule from '../src';
 
 import {PassThrough} from 'stream';
 
-import {protobuf, LROperation} from 'google-gax';
+import {protobuf, LROperation, operationsProtos} from 'google-gax';
 
 function generateSampleMessage<T extends object>(instance: T) {
   const filledObject = (instance.constructor as typeof protobuf.Message).toObject(
@@ -331,9 +331,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.createProductSet(request);
-      }, expectedError);
+      await assert.rejects(client.createProductSet(request), expectedError);
       assert(
         (client.innerApiCalls.createProductSet as SinonStub)
           .getCall(0)
@@ -445,9 +443,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getProductSet(request);
-      }, expectedError);
+      await assert.rejects(client.getProductSet(request), expectedError);
       assert(
         (client.innerApiCalls.getProductSet as SinonStub)
           .getCall(0)
@@ -562,9 +558,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.updateProductSet(request);
-      }, expectedError);
+      await assert.rejects(client.updateProductSet(request), expectedError);
       assert(
         (client.innerApiCalls.updateProductSet as SinonStub)
           .getCall(0)
@@ -676,9 +670,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.deleteProductSet(request);
-      }, expectedError);
+      await assert.rejects(client.deleteProductSet(request), expectedError);
       assert(
         (client.innerApiCalls.deleteProductSet as SinonStub)
           .getCall(0)
@@ -790,9 +782,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.createProduct(request);
-      }, expectedError);
+      await assert.rejects(client.createProduct(request), expectedError);
       assert(
         (client.innerApiCalls.createProduct as SinonStub)
           .getCall(0)
@@ -904,9 +894,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getProduct(request);
-      }, expectedError);
+      await assert.rejects(client.getProduct(request), expectedError);
       assert(
         (client.innerApiCalls.getProduct as SinonStub)
           .getCall(0)
@@ -1021,9 +1009,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.updateProduct(request);
-      }, expectedError);
+      await assert.rejects(client.updateProduct(request), expectedError);
       assert(
         (client.innerApiCalls.updateProduct as SinonStub)
           .getCall(0)
@@ -1135,9 +1121,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.deleteProduct(request);
-      }, expectedError);
+      await assert.rejects(client.deleteProduct(request), expectedError);
       assert(
         (client.innerApiCalls.deleteProduct as SinonStub)
           .getCall(0)
@@ -1251,9 +1235,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.createReferenceImage(request);
-      }, expectedError);
+      await assert.rejects(client.createReferenceImage(request), expectedError);
       assert(
         (client.innerApiCalls.createReferenceImage as SinonStub)
           .getCall(0)
@@ -1367,9 +1349,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.deleteReferenceImage(request);
-      }, expectedError);
+      await assert.rejects(client.deleteReferenceImage(request), expectedError);
       assert(
         (client.innerApiCalls.deleteReferenceImage as SinonStub)
           .getCall(0)
@@ -1481,9 +1461,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getReferenceImage(request);
-      }, expectedError);
+      await assert.rejects(client.getReferenceImage(request), expectedError);
       assert(
         (client.innerApiCalls.getReferenceImage as SinonStub)
           .getCall(0)
@@ -1597,9 +1575,10 @@ describe('v1p4beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.addProductToProductSet(request);
-      }, expectedError);
+      await assert.rejects(
+        client.addProductToProductSet(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.addProductToProductSet as SinonStub)
           .getCall(0)
@@ -1713,9 +1692,10 @@ describe('v1p4beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.removeProductFromProductSet(request);
-      }, expectedError);
+      await assert.rejects(
+        client.removeProductFromProductSet(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.removeProductFromProductSet as SinonStub)
           .getCall(0)
@@ -1837,9 +1817,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.importProductSets(request);
-      }, expectedError);
+      await assert.rejects(client.importProductSets(request), expectedError);
       assert(
         (client.innerApiCalls.importProductSets as SinonStub)
           .getCall(0)
@@ -1872,14 +1850,53 @@ describe('v1p4beta1.ProductSearchClient', () => {
         expectedError
       );
       const [operation] = await client.importProductSets(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.importProductSets as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkImportProductSetsProgress without error', async () => {
+      const client = new productsearchModule.v1p4beta1.ProductSearchClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkImportProductSetsProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkImportProductSetsProgress with error', async () => {
+      const client = new productsearchModule.v1p4beta1.ProductSearchClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkImportProductSetsProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -1996,9 +2013,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.purgeProducts(request);
-      }, expectedError);
+      await assert.rejects(client.purgeProducts(request), expectedError);
       assert(
         (client.innerApiCalls.purgeProducts as SinonStub)
           .getCall(0)
@@ -2031,14 +2046,53 @@ describe('v1p4beta1.ProductSearchClient', () => {
         expectedError
       );
       const [operation] = await client.purgeProducts(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.purgeProducts as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkPurgeProductsProgress without error', async () => {
+      const client = new productsearchModule.v1p4beta1.ProductSearchClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkPurgeProductsProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkPurgeProductsProgress with error', async () => {
+      const client = new productsearchModule.v1p4beta1.ProductSearchClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkPurgeProductsProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -2161,9 +2215,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listProductSets(request);
-      }, expectedError);
+      await assert.rejects(client.listProductSets(request), expectedError);
       assert(
         (client.innerApiCalls.listProductSets as SinonStub)
           .getCall(0)
@@ -2260,9 +2312,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listProductSets.createStream as SinonStub)
           .getCall(0)
@@ -2479,9 +2529,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listProducts(request);
-      }, expectedError);
+      await assert.rejects(client.listProducts(request), expectedError);
       assert(
         (client.innerApiCalls.listProducts as SinonStub)
           .getCall(0)
@@ -2578,9 +2626,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listProducts.createStream as SinonStub)
           .getCall(0)
@@ -2801,9 +2847,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listReferenceImages(request);
-      }, expectedError);
+      await assert.rejects(client.listReferenceImages(request), expectedError);
       assert(
         (client.innerApiCalls.listReferenceImages as SinonStub)
           .getCall(0)
@@ -2900,9 +2944,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listReferenceImages.createStream as SinonStub)
           .getCall(0)
@@ -3121,9 +3163,10 @@ describe('v1p4beta1.ProductSearchClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listProductsInProductSet(request);
-      }, expectedError);
+      await assert.rejects(
+        client.listProductsInProductSet(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.listProductsInProductSet as SinonStub)
           .getCall(0)
@@ -3221,9 +3264,7 @@ describe('v1p4beta1.ProductSearchClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listProductsInProductSet
           .createStream as SinonStub)


### PR DESCRIPTION
For each client method returning a long running operation, a separate method to check its status is added.

Added methods: `checkAsyncBatchAnnotateFilesProgress`, `checkAsyncBatchAnnotateImagesProgress`, `checkImportProductSetsProgress`, `checkPurgeProductsProgress`.