### PR TITLE
fix(samples): use pureimage instead of canvas

### DIFF
--- a/samples/package.json
+++ b/samples/package.json
@@ -14,9 +14,9 @@
   },
   "dependencies": {
     "@google-cloud/vision": "^1.11.0",
-    "canvas": "^2.0.0",
     "mathjs": "^6.0.0",
     "natural": "^1.0.0",
+    "pureimage": "^0.2.1",
     "redis": "^3.0.0",
     "yargs": "^15.0.0"
   },


### PR DESCRIPTION
The face detection sample in Vision uses [`canvas`](https://www.npmjs.com/package/canvas) module to draw rectangles to highlight faces. One problem here is that `canvas` has a binary dependency, uses `node-gyp`, falls back to compilation of the native code, and started failing :)

So... there is this new module called [`pureimage`](https://www.npmjs.com/package/pureimage) which is at version 0.2.1 at this time and has just 1250 weekly downloads, and I would've never picked it but... it's written in pure JavaScript, and seems like it does its job! For our simple task of drawing a rectangle over the face, it just works, and with only small code changes (and even better promise interface than `canvas`).

What do you think?

![image](https://user-images.githubusercontent.com/4015807/81143970-f2e7de80-8f27-11ea-919e-b221760c29c0.png)
(this is a picture from our samples, after face detection, with a rectangle drawn by `pureimage`)