### PR TITLE
fix: update URL system test to retrieve image from Google server

### DIFF
--- a/system-test/vision.ts
+++ b/system-test/vision.ts
@@ -72,7 +72,7 @@ describe('Vision', () => {
   it('should detect from a URL', function () {
     this.retries(3);
     const url =
-      'https://upload.wikimedia.org/wikipedia/commons/5/51/Google.png';
+      'https://lh3.googleusercontent.com/d_S5gxu_S1P6NR1gXeMthZeBzkrQMHdI5uvXrpn3nfJuXpCjlqhLQKH_hbOxTHxFhp5WugVOEcl4WDrv9rmKBDOMExhKU5KmmLFQVg';
     return client
       .logoDetection(url)
       .then(


### PR DESCRIPTION
Updated system test to retrieve Google logo from Google-hosted domain, rather than wikimedia, to potentially reduce test instability.

Fixes #945 🦕
